### PR TITLE
[ENTESB-2410]Soap-quickstart tests included in distribution are failing ...

### DIFF
--- a/quickstarts/cxf/soap/src/test/resources/request.xml
+++ b/quickstarts/cxf/soap/src/test/resources/request.xml
@@ -17,7 +17,7 @@
 -->
 <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
     <soap:Body>
-        <ns2:sayHi xmlns:ns2="http://soap.fabric.quickstarts.fabric8.io/">
+        <ns2:sayHi xmlns:ns2="http://soap.quickstarts.fabric8.io/">
             <arg0>John Doe</arg0>
         </ns2:sayHi>
     </soap:Body>


### PR DESCRIPTION
...due to bad xmlns definiton
