### PR TITLE
Fixes ENTESB-2222: Adds an ssl-broker.xml config file to the mq-replicat...

### DIFF
--- a/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/mq/replicated.profile/broker.xml
+++ b/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/mq/replicated.profile/broker.xml
@@ -80,10 +80,11 @@
         </systemUsage>
 
         <transportConnectors>
-            <transportConnector name="openwire" uri="tcp://0.0.0.0:0"/>
-            <transportConnector name="mqtt"     uri="mqtt://0.0.0.0:0"/>
-            <transportConnector name="amqp"     uri="amqp://0.0.0.0:0"/>
-            <transportConnector name="stomp"    uri="stomp://0.0.0.0:0"/>
+            <transportConnector name="openwire"     uri="tcp://0.0.0.0:0"/>
+            <transportConnector name="mqtt"         uri="mqtt://0.0.0.0:0"/>
+            <transportConnector name="amqp"         uri="amqp://0.0.0.0:0"/>
+            <transportConnector name="stomp"        uri="stomp://0.0.0.0:0"/>
+            <transportConnector name="ws"           uri="ws://0.0.0.0:0"/>
         </transportConnectors>
     </broker>
 

--- a/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/mq/replicated.profile/ssl-broker.xml
+++ b/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/mq/replicated.profile/ssl-broker.xml
@@ -29,7 +29,7 @@
         <property name="searchSystemEnvironment" value="true"/>
     </bean>
 
-    <broker xmlns="http://activemq.apache.org/schema/core" brokerName="${broker-name}" dataDirectory="${data}" start="false" restartAllowed="false">
+    <broker xmlns="http://activemq.apache.org/schema/core" brokerName="${broker-name}" dataDirectory="${data}" start="false">
 
         <destinationPolicy>
             <policyMap>
@@ -50,15 +50,14 @@
         </managementContext>
 
         <persistenceAdapter>
-            <replicatedLevelDB directory="${data}/leveldb/${karaf.name}"
+            <replicatedLevelDB directory="${data}/leveldb/${runtime.id}"
               replicas="${replicas}"
               zkAddress="${zookeeper.url}"
               zkPassword="${zookeeper.password}"
-              zkPath="/fabric/registry/clusters/fusemq-replication-elections/${group}"
+              zkPath="/fabric/registry/clusters/amq-replication-elections/${group}"
               securityToken="${zookeeper.password}"
+              hostname="${container.ip}"
               container="${container.id}"
-              bind="tcp://${bind.address}:${OPENSHIFT_FUSE_REPLICATION_PORT}"
-              connectUrl="tcp://${OPENSHIFT_GEAR_DNS}:${OPENSHIFT_FUSE_REPLICATION_PROXY_PORT}"
               />
         </persistenceAdapter>
 

--- a/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/mq/replicated.profile/ssl-broker.xml#openshift
+++ b/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/mq/replicated.profile/ssl-broker.xml#openshift
@@ -82,11 +82,11 @@
 
 
         <sslContext>
-            <sslContext
-                keyStore="${keystore.url}"
-                keyStorePassword="${zookeeper.password}"
-                trustStore="${keystore.url}"
-                trustStorePassword="${zookeeper.password}"
+            <sslContext 
+                keyStore="${keystore.file}" 
+                keyStorePassword="${keystore.password}" 
+                trustStore="${truststore.file}"  
+                trustStorePassword="${truststore.password}"
                 />
         </sslContext>
 


### PR DESCRIPTION
...ed profile so ssl enabled brokers can be replicated too.  Also adds in openshift versions of the config.
