### PR TITLE
FABRIC-1229: fabric-create fails with 'Unable to update agent'

### DIFF
--- a/fabric/fabric-agent/pom.xml
+++ b/fabric/fabric-agent/pom.xml
@@ -53,7 +53,6 @@
             org.apache.karaf.features;
             org.apache.karaf.features.internal;
             org.apache.karaf.util.collections;
-            org.apache.karaf.util.bundles;
             io.fabric8.agent;
             io.fabric8.agent.download.impl;
             io.fabric8.agent.internal;

--- a/fabric/fabric-agent/src/main/java/io/fabric8/agent/service/Agent.java
+++ b/fabric/fabric-agent/src/main/java/io/fabric8/agent/service/Agent.java
@@ -423,15 +423,8 @@ public class Agent {
         }
 
         @Override
-        public void updateBundle(Bundle bundle, String uri, InputStream is) throws BundleException {
-            // We need to wrap the bundle to insert a Bundle-UpdateLocation header
-            try {
-                File file = BundleUtils.fixBundleWithUpdateLocation(is, uri);
-                bundle.update(new FileInputStream(file));
-                file.delete();
-            } catch (IOException e) {
-                throw new BundleException("Unable to update bundle", e);
-            }
+        public void updateBundle(Bundle bundle, InputStream is) throws BundleException {
+            bundle.update(is);
         }
 
         @Override

--- a/fabric/fabric-agent/src/main/java/io/fabric8/agent/service/Deployer.java
+++ b/fabric/fabric-agent/src/main/java/io/fabric8/agent/service/Deployer.java
@@ -109,7 +109,7 @@ public class Deployer {
         void installFeatureConfigs(Feature feature) throws IOException, InvalidSyntaxException;
 
         Bundle installBundle(String region, String uri, InputStream is) throws BundleException;
-        void updateBundle(Bundle bundle, String uri, InputStream is) throws BundleException;
+        void updateBundle(Bundle bundle, InputStream is) throws BundleException;
         void uninstall(Bundle bundle) throws BundleException;
         void startBundle(Bundle bundle) throws BundleException;
         void stopBundle(Bundle bundle, int options) throws BundleException;
@@ -518,7 +518,7 @@ public class Deployer {
             try (
                     InputStream is = getBundleInputStream(resource, providers)
             ) {
-                callback.updateBundle(dstate.serviceBundle, uri, is);
+                callback.updateBundle(dstate.serviceBundle, is);
             }
             callback.refreshPackages(toRefresh);
             callback.startBundle(dstate.serviceBundle);
@@ -655,7 +655,7 @@ public class Deployer {
                     try (
                             InputStream is = getBundleInputStream(resource, providers)
                     ) {
-                        callback.updateBundle(bundle, uri, is);
+                        callback.updateBundle(bundle, is);
                     }
                     toStart.add(bundle);
                 }
@@ -783,7 +783,7 @@ public class Deployer {
         callback.phase("finalizing (resolving bundles)");
         toResolve.addAll(toStart);
         toResolve.addAll(toRefresh);
-        removeBundlesInState(toResolve, UNINSTALLED);
+        removeFragmentsAndBundlesInState(toResolve, UNINSTALLED);
         callback.resolveBundles(toResolve, resolver.getWiring(), deployment.resToBnd);
 
         // Compute bundles to start
@@ -960,15 +960,6 @@ public class Deployer {
             Bundle bundle = iterator.next();
             if ((bundle.getState() & state) != 0
                     || bundle.getHeaders().get(org.osgi.framework.Constants.FRAGMENT_HOST) != null) {
-                iterator.remove();
-            }
-        }
-    }
-
-    private void removeBundlesInState(Collection<Bundle> bundles, int state) {
-        for (Iterator<Bundle> iterator = bundles.iterator(); iterator.hasNext();) {
-            Bundle bundle = iterator.next();
-            if ((bundle.getState() & state) != 0) {
                 iterator.remove();
             }
         }

--- a/patch/patch-core/pom.xml
+++ b/patch/patch-core/pom.xml
@@ -42,7 +42,6 @@
         <fuse.osgi.private.pkg>
             org.apache.felix.utils.manifest,
             org.apache.felix.utils.version,
-            org.apache.karaf.util.bundles,
             io.fabric8.common.util
         </fuse.osgi.private.pkg>
     </properties>
@@ -57,11 +56,6 @@
       <dependency>
           <groupId>org.osgi</groupId>
           <artifactId>org.osgi.core</artifactId>
-      </dependency>
-
-      <dependency>
-          <groupId>org.apache.karaf</groupId>
-          <artifactId>org.apache.karaf.util</artifactId>
       </dependency>
 
       <dependency>

--- a/patch/patch-core/src/main/java/io/fabric8/patch/impl/ServiceImpl.java
+++ b/patch/patch-core/src/main/java/io/fabric8/patch/impl/ServiceImpl.java
@@ -56,7 +56,6 @@ import io.fabric8.patch.BundleUpdate;
 import io.fabric8.patch.PatchException;
 import io.fabric8.patch.Result;
 import io.fabric8.patch.Service;
-import org.apache.karaf.util.bundles.BundleUtils;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleException;
@@ -484,10 +483,15 @@ public class ServiceImpl implements Service {
         Set<Bundle> toRefresh = new HashSet<Bundle>();
         Set<Bundle> toStart = new HashSet<Bundle>();
         for (Map.Entry<Bundle, String> e : toUpdate.entrySet()) {
-            Bundle bundle = e.getKey();
-            BundleUtils.update(bundle, new URL(e.getValue()));
-            toRefresh.add(bundle);
-            toStart.add(bundle);
+            InputStream is = new URL(e.getValue()).openStream();
+            try {
+                Bundle bundle = e.getKey();
+                bundle.update(is);
+                toRefresh.add(bundle);
+                toStart.add(bundle);
+            } finally {
+                is.close();
+            }
         }
         findBundlesWithOptionalPackagesToRefresh(toRefresh);
         findBundlesWithFramentsToRefresh(toRefresh);


### PR DESCRIPTION
Revert "[ENTESB-2387] Karaf command "osgi:list -l" still shows location of old bundles even after patch is installed successfully in fabric"

This reverts commit bf211cc13026ca630019837820e0dd75704a574a.
