### PR TITLE
Fixes ENTESB-2488: Wrong record for master component in the zookeper reg...

### DIFF
--- a/fabric/fabric-camel/src/main/java/io/fabric8/camel/MasterComponent.java
+++ b/fabric/fabric-camel/src/main/java/io/fabric8/camel/MasterComponent.java
@@ -27,7 +27,7 @@ import java.util.Map;
  * taking over to provide high availability of a single consumer.
  */
 public class MasterComponent extends ZKComponentSupport {
-    private String zkRoot = "/fabric/registry/camel/master";
+    private String zkRoot = "/fabric/registry/clusters/camel/master";
 
     public String getZkRoot() {
         return zkRoot;

--- a/fabric/fabric-commands/src/main/java/io/fabric8/commands/ClusterListAction.java
+++ b/fabric/fabric-commands/src/main/java/io/fabric8/commands/ClusterListAction.java
@@ -120,7 +120,12 @@ public class ClusterListAction extends AbstractAction {
                                 node.slaves.add(agent);
                             }
                         } else {
-                            node.slaves.add(agent);
+                            Object started = value(map, "started");
+                            if( started == Boolean.TRUE ) {
+                                node.masters.add(agent);
+                            } else {
+                                node.slaves.add(agent);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
...istry
- master endpoints now show up in the fabric:cluster-list
- consumer and started field is properly set now
