### PR TITLE
Fix for FABRIC-1224: Passwords in logs are clear text

### DIFF
--- a/fabric/fabric-boot-commands/src/main/java/io/fabric8/boot/commands/BootCommandLoggingFilter.java
+++ b/fabric/fabric-boot-commands/src/main/java/io/fabric8/boot/commands/BootCommandLoggingFilter.java
@@ -1,0 +1,34 @@
+/**
+ *  Copyright 2005-2015 Red Hat, Inc.
+ *
+ *  Red Hat licenses this file to you under the Apache License, version
+ *  2.0 (the "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *  implied.  See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+package io.fabric8.boot.commands;
+
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Service;
+import org.apache.karaf.shell.console.CommandLoggingFilter;
+import org.apache.karaf.shell.console.RegexCommandLoggingFilter;
+
+/**
+ * Used to filter out passwords from command logging.
+ */
+@Component(immediate = true)
+@Service({ CommandLoggingFilter.class })
+public class BootCommandLoggingFilter extends RegexCommandLoggingFilter {
+    public BootCommandLoggingFilter() {
+        addCommandOption("--zookeeper-password", CreateCommand.FUNCTION_VALUE, JoinCommand.FUNCTION_VALUE);
+        addCommandOption("--new-user-password", CreateCommand.FUNCTION_VALUE);
+        addCommandOption("--external-git-password", CreateCommand.FUNCTION_VALUE);
+    }
+}

--- a/fabric/fabric-commands/src/main/java/io/fabric8/commands/EnsemblePasswordCommandLoggingFilter.java
+++ b/fabric/fabric-commands/src/main/java/io/fabric8/commands/EnsemblePasswordCommandLoggingFilter.java
@@ -1,0 +1,32 @@
+/**
+ *  Copyright 2005-2015 Red Hat, Inc.
+ *
+ *  Red Hat licenses this file to you under the Apache License, version
+ *  2.0 (the "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *  implied.  See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+package io.fabric8.commands;
+
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Service;
+import org.apache.karaf.shell.console.CommandLoggingFilter;
+import org.apache.karaf.shell.console.RegexCommandLoggingFilter;
+
+/**
+ * Used to filter out passwords from command logging.
+ */
+@Component(immediate = true)
+@Service({ CommandLoggingFilter.class })
+public class EnsemblePasswordCommandLoggingFilter extends RegexCommandLoggingFilter {
+    public EnsemblePasswordCommandLoggingFilter() {
+        setPattern(EnsemblePassword.FUNCTION_VALUE + " +([^ ]+)");
+    }
+}

--- a/fabric/fabric-commands/src/main/java/io/fabric8/commands/FabricCommandLoggingFilter.java
+++ b/fabric/fabric-commands/src/main/java/io/fabric8/commands/FabricCommandLoggingFilter.java
@@ -1,0 +1,48 @@
+/**
+ *  Copyright 2005-2015 Red Hat, Inc.
+ *
+ *  Red Hat licenses this file to you under the Apache License, version
+ *  2.0 (the "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *  implied.  See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+package io.fabric8.commands;
+
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Service;
+import org.apache.karaf.shell.console.CommandLoggingFilter;
+import org.apache.karaf.shell.console.RegexCommandLoggingFilter;
+
+/**
+ * Used to filter out passwords from command logging.
+ */
+@Component(immediate = true)
+@Service({CommandLoggingFilter.class})
+public class FabricCommandLoggingFilter extends RegexCommandLoggingFilter {
+    public FabricCommandLoggingFilter() {
+
+        addCommandOption("--jmx-password", ContainerCreateChild.FUNCTION_VALUE, MQCreate.FUNCTION_VALUE);
+        addCommandOption("--zookeeper-password", ContainerCreateChild.FUNCTION_VALUE);
+        addCommandOption("--new-zookeeper-password", EnsembleAdd.FUNCTION_VALUE, EnsembleRemove.FUNCTION_VALUE);
+        addCommandOption("--networks-password", MQCreate.FUNCTION_VALUE);
+        addCommandOption("-p", ContainerConnect.FUNCTION_VALUE,
+                ContainerEditJvmOptions.FUNCTION_VALUE,
+                Encrypt.FUNCTION_VALUE,
+                PatchApply.FUNCTION_VALUE);
+        addCommandOption("--password",
+                ContainerConnect.FUNCTION_VALUE,
+                ContainerEditJvmOptions.FUNCTION_VALUE,
+                Encrypt.FUNCTION_VALUE,
+                PatchApply.FUNCTION_VALUE,
+                ContainerDelete.FUNCTION_VALUE,
+                ContainerStop.FUNCTION_VALUE,
+                ContainerStart.FUNCTION_VALUE);
+    }
+}

--- a/fabric/fabric-core-agent-jclouds/src/main/java/io/fabric8/service/jclouds/commands/ContainerCreateCloudCommandLoggingFilter.java
+++ b/fabric/fabric-core-agent-jclouds/src/main/java/io/fabric8/service/jclouds/commands/ContainerCreateCloudCommandLoggingFilter.java
@@ -1,0 +1,39 @@
+/**
+ *  Copyright 2005-2015 Red Hat, Inc.
+ *
+ *  Red Hat licenses this file to you under the Apache License, version
+ *  2.0 (the "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *  implied.  See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+package io.fabric8.service.jclouds.commands;
+
+import io.fabric8.commands.ContainerConnect;
+import io.fabric8.commands.ContainerEditJvmOptions;
+import io.fabric8.commands.Encrypt;
+import io.fabric8.commands.PatchApply;
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Service;
+import org.apache.karaf.shell.console.CommandLoggingFilter;
+import org.apache.karaf.shell.console.RegexCommandLoggingFilter;
+
+/**
+ * Used to filter out passwords from command logging.
+ */
+@Component(immediate = true)
+@Service({ CommandLoggingFilter.class })
+public class ContainerCreateCloudCommandLoggingFilter extends RegexCommandLoggingFilter {
+    public ContainerCreateCloudCommandLoggingFilter() {
+        addCommandOption("--password", "container-create-cloud");
+        addCommandOption("--new-user-password", "container-create-cloud");
+        addCommandOption("--zookeeper-password", "container-create-cloud");
+        setGroup(2);
+    }
+}

--- a/fabric/fabric-core-agent-ssh/src/main/java/io/fabric8/service/ssh/commands/ContainerCreateSshCommandLoggingFilter.java
+++ b/fabric/fabric-core-agent-ssh/src/main/java/io/fabric8/service/ssh/commands/ContainerCreateSshCommandLoggingFilter.java
@@ -1,0 +1,35 @@
+/**
+ *  Copyright 2005-2015 Red Hat, Inc.
+ *
+ *  Red Hat licenses this file to you under the Apache License, version
+ *  2.0 (the "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *  implied.  See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+package io.fabric8.service.ssh.commands;
+
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Service;
+import org.apache.karaf.shell.console.CommandLoggingFilter;
+import org.apache.karaf.shell.console.RegexCommandLoggingFilter;
+
+/**
+ * Used to filter out passwords from command logging.
+ */
+@Component(immediate = true)
+@Service({ CommandLoggingFilter.class })
+public class ContainerCreateSshCommandLoggingFilter extends RegexCommandLoggingFilter {
+    public ContainerCreateSshCommandLoggingFilter() {
+        addCommandOption("--password", "container-create-ssh");
+        addCommandOption("--new-user-password", "container-create-ssh");
+        addCommandOption("--zookeeper-password", "container-create-ssh");
+        addCommandOption("--pass-phrase", "container-create-ssh");
+    }
+}

--- a/fabric/fabric-openshift/src/main/java/io/fabric8/openshift/commands/OpenshiftCommandLoggingFilter.java
+++ b/fabric/fabric-openshift/src/main/java/io/fabric8/openshift/commands/OpenshiftCommandLoggingFilter.java
@@ -1,0 +1,42 @@
+/**
+ *  Copyright 2005-2015 Red Hat, Inc.
+ *
+ *  Red Hat licenses this file to you under the Apache License, version
+ *  2.0 (the "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *  implied.  See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+package io.fabric8.openshift.commands;
+
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Service;
+import org.apache.karaf.shell.console.CommandLoggingFilter;
+import org.apache.karaf.shell.console.RegexCommandLoggingFilter;
+
+/**
+ * Used to filter out passwords from command logging.
+ */
+@Component(immediate = true)
+@Service({ CommandLoggingFilter.class })
+public class OpenshiftCommandLoggingFilter extends RegexCommandLoggingFilter {
+    public OpenshiftCommandLoggingFilter() {
+        addCommandOption("--zookeeper-password", "container-create-openshift");
+        addCommandOption("--password",
+                "container-create-openshift",
+                ApplicationInfo.FUNCTION_VALUE,
+                ApplicationCreate.FUNCTION_VALUE,
+                ApplicationStart.FUNCTION_VALUE,
+                ApplicationStop.FUNCTION_VALUE,
+                ApplicationList.FUNCTION_VALUE,
+                ApplicationRestart.FUNCTION_VALUE,
+                ApplicationDestroy.FUNCTION_VALUE,
+                DomainList.FUNCTION_VALUE);
+    }
+}


### PR DESCRIPTION
Added logging filters for fabric commands.
