### PR TITLE
ZKComponentSupport now also looks at env vars to set zookeeper url

### DIFF
--- a/fabric/fabric-camel/src/main/java/io/fabric8/camel/ZKComponentSupport.java
+++ b/fabric/fabric-camel/src/main/java/io/fabric8/camel/ZKComponentSupport.java
@@ -33,6 +33,9 @@ public abstract class ZKComponentSupport extends DefaultComponent implements Cal
     private static final transient Log LOG = LogFactory.getLog(MasterComponent.class);
     private static final String ZOOKEEPER_URL = "zookeeper.url";
     private static final String ZOOKEEPER_PASSWORD = "zookeeper.password";
+    private static final String ZOOKEEPER_URL_ENV = "ZOOKEEPER_URL";
+    private static final String ZOOKEEPER_HOST_ENV = "ZK_CLIENT_SERVICE_HOST";
+    private static final String ZOOKEEPER_PORT_ENV = "ZK_CLIENT_SERVICE_PORT";
 
     private ManagedGroupFactory managedGroupFactory;
     private CuratorFramework curator;
@@ -110,6 +113,16 @@ public abstract class ZKComponentSupport extends DefaultComponent implements Cal
 
     public CuratorFramework call() throws Exception {
         String connectString = getZooKeeperUrl();
+        if (connectString == null) {
+            connectString = System.getenv(ZOOKEEPER_URL_ENV);
+        }
+        if (connectString == null) {
+            String zkHost = System.getenv(ZOOKEEPER_HOST_ENV);
+            if (zkHost != null) {
+                String zkPort = System.getenv(ZOOKEEPER_PORT_ENV);
+                connectString = zkHost + ":" + (zkPort == null ? "2181" : zkPort);
+            }
+        }
         if (connectString == null) {
             connectString = System.getProperty(ZOOKEEPER_URL, "localhost:2181");
         }


### PR DESCRIPTION
This makes it possible to use the Master&Fabric components when Fuse is running inside OpenShift/Kubernetes
