### PR TITLE
[ENTESB-2939] fix ssl-broker.xml in mq.replicated profile

### DIFF
--- a/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/mq/replicated.profile/ssl-broker.xml
+++ b/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/mq/replicated.profile/ssl-broker.xml
@@ -80,10 +80,10 @@
 
         <sslContext>
             <sslContext
-                keyStore="${keystore.url}"
-                keyStorePassword="${zookeeper.password}"
-                trustStore="${keystore.url}"
-                trustStorePassword="${zookeeper.password}"
+                keyStore="${keystore.file}"
+                keyStorePassword="${keystore.password}"
+                trustStore="${truststore.file}"
+                trustStorePassword="${truststore.password}"
                 />
         </sslContext>
 


### PR DESCRIPTION
https://issues.jboss.org/browse/ENTESB-2939 quick fix to use correct placeholders in sslContext, similarly to base.profile configuration
