### PR TITLE
Fixes ENTESB-3301: Only use the standalone pid key to determine if br…

### DIFF
--- a/mq/mq-fabric/src/main/java/io/fabric8/mq/fabric/ActiveMQServiceFactory.java
+++ b/mq/mq-fabric/src/main/java/io/fabric8/mq/fabric/ActiveMQServiceFactory.java
@@ -372,8 +372,7 @@ public class ActiveMQServiceFactory  {
             this.connectors = connectorsProperty.split("\\s");
 
             this.replicating = "true".equalsIgnoreCase(properties.getProperty("replicating"));
-            this.standalone = "true".equalsIgnoreCase(properties.getProperty("standalone")) ||
-                    "standalone".equalsIgnoreCase(properties.getProperty("kind"));
+            this.standalone = "true".equalsIgnoreCase(properties.getProperty("standalone"));
             this.registerService = "true".equalsIgnoreCase(properties.getProperty("registerService"));
             this.configCheck = "true".equalsIgnoreCase(properties.getProperty("config.check"));
 

--- a/mq/mq-fabric/src/main/java/io/fabric8/mq/fabric/BrokerDeployment.java
+++ b/mq/mq-fabric/src/main/java/io/fabric8/mq/fabric/BrokerDeployment.java
@@ -50,8 +50,7 @@ public class BrokerDeployment {
 
     @Activate
     void activate(Map<String, ?> configuration) throws Exception {
-        boolean standalone = "true".equalsIgnoreCase((String) configuration.get("standalone")) ||
-                "standalone".equalsIgnoreCase((String) configuration.get("kind"));
+        boolean standalone = "true".equalsIgnoreCase((String) configuration.get("standalone"));
 
         String factoryPid = standalone ?
                 "io.fabric8.mq.fabric.standalone.server" :


### PR DESCRIPTION
…oker should be created in non-fabric node.  The kind=standalone property is means something different.

kind=StandAlone means a single broker in a fabric.
