### PR TITLE
[ENTESB-2436][ENTESB-3494] Switch to Aether 1.0.2.v20150114

### DIFF
--- a/fabric/fabric-core/src/main/java/io/fabric8/service/FreeGeoIpService.java
+++ b/fabric/fabric-core/src/main/java/io/fabric8/service/FreeGeoIpService.java
@@ -46,7 +46,7 @@ public class FreeGeoIpService implements GeoLocationService{
             String urlStr = "http://freegeoip.net/json/";
             URL url = new URL(urlStr);
             URLConnection urlConnection = url.openConnection();
-            urlConnection.setConnectTimeout(50000);
+            urlConnection.setConnectTimeout(2000);
             urlConnection.setReadTimeout(5000);
             InputStream is = urlConnection.getInputStream();
             closeable = is;

--- a/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/default.profile/io.fabric8.maven.properties
+++ b/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/default.profile/io.fabric8.maven.properties
@@ -19,3 +19,5 @@ io.fabric8.maven.useFallbackRepositories = false
 # Make sure that parts that are using pax-url have visibility to the location where the agent downloads artifacts.
 # This is not added to the agent configuration, since it would break SNAPSHOTS
 io.fabric8.maven.repositories = ${profile:io.fabric8.agent/org.ops4j.pax.url.mvn.repositories}
+
+io.fabric8.maven.localRepository = ${karaf.data}/repository

--- a/itests/basic/karaf/src/test/java/io/fabric8/itests/basic/karaf/ContainerRegistrationTest.java
+++ b/itests/basic/karaf/src/test/java/io/fabric8/itests/basic/karaf/ContainerRegistrationTest.java
@@ -54,7 +54,7 @@ public class ContainerRegistrationTest {
     @Deployment
     @StartLevelAware(autostart = true)
     public static Archive<?> deployment() {
-        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "container-registration-test");
+        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "container-registration-test.jar");
         archive.addPackage(CommandSupport.class.getPackage());
         archive.setManifest(new Asset() {
             @Override

--- a/itests/basic/karaf/src/test/java/io/fabric8/itests/basic/karaf/ExtendedCreateChildContainerTest.java
+++ b/itests/basic/karaf/src/test/java/io/fabric8/itests/basic/karaf/ExtendedCreateChildContainerTest.java
@@ -54,7 +54,7 @@ public class ExtendedCreateChildContainerTest {
     @Deployment
     @StartLevelAware(autostart = true)
     public static Archive<?> deployment() {
-        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "extended-child-container-test");
+        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "extended-child-container-test.jar");
         archive.addPackage(CommandSupport.class.getPackage());
         archive.setManifest(new Asset() {
             @Override

--- a/itests/basic/karaf/src/test/java/io/fabric8/itests/basic/karaf/ExtendedEnsembleTest.java
+++ b/itests/basic/karaf/src/test/java/io/fabric8/itests/basic/karaf/ExtendedEnsembleTest.java
@@ -58,7 +58,7 @@ public class ExtendedEnsembleTest {
     @Deployment
     @StartLevelAware(autostart = true)
     public static Archive<?> deployment() {
-        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "extended-ensemble-test");
+        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "extended-ensemble-test.jar");
         archive.addPackage(CommandSupport.class.getPackage());
         archive.setManifest(new Asset() {
             @Override

--- a/itests/basic/karaf/src/test/java/io/fabric8/itests/basic/karaf/ExtendedJoinTest.java
+++ b/itests/basic/karaf/src/test/java/io/fabric8/itests/basic/karaf/ExtendedJoinTest.java
@@ -53,7 +53,7 @@ public class ExtendedJoinTest {
     @Deployment
     @StartLevelAware(autostart = true)
     public static Archive<?> deployment() {
-        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "extended-join-test");
+        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "extended-join-test.jar");
         archive.addPackage(CommandSupport.class.getPackage());
         archive.setManifest(new Asset() {
             @Override

--- a/itests/basic/karaf/src/test/java/io/fabric8/itests/basic/karaf/ExtendedUpgradeAndRollbackTest.java
+++ b/itests/basic/karaf/src/test/java/io/fabric8/itests/basic/karaf/ExtendedUpgradeAndRollbackTest.java
@@ -55,7 +55,7 @@ public class ExtendedUpgradeAndRollbackTest  {
     @Deployment
     @StartLevelAware(autostart = true)
     public static Archive<?> deployment() {
-        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "extended-upgrade-rollback-test");
+        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "extended-upgrade-rollback-test.jar");
         archive.addPackage(CommandSupport.class.getPackage());
         archive.setManifest(new Asset() {
             @Override

--- a/itests/basic/karaf/src/test/java/io/fabric8/itests/basic/karaf/ResolverTest.java
+++ b/itests/basic/karaf/src/test/java/io/fabric8/itests/basic/karaf/ResolverTest.java
@@ -56,7 +56,7 @@ public class ResolverTest {
     @Deployment
     @StartLevelAware(autostart = true)
     public static Archive<?> deployment() {
-        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "resolver-test");
+        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "resolver-test.jar");
         archive.addPackage(CommandSupport.class.getPackage());
         archive.setManifest(new Asset() {
             @Override

--- a/itests/basic/karaf/src/test/resources/arquillian.xml
+++ b/itests/basic/karaf/src/test/resources/arquillian.xml
@@ -24,7 +24,7 @@
 			<property name="karafHome">${karaf.home}</property>
             <property name="allowConnectingToRunningServer">true</property>
             <property name="bootstrapCompleteService">io.fabric8.api.ZooKeeperClusterBootstrap</property>
-            <property name="javaVmArguments">-Xmx1536m -Dfabric.version=${project.version} -agentlib:jdwp=transport=dt_socket,address=5005,server=y,suspend=n</property>
+            <property name="javaVmArguments">-Xmx1536m -Djava.net.preferIPv4Stack=true -Dfabric.version=${project.version} -agentlib:jdwp=transport=dt_socket,address=5005,server=y,suspend=n</property>
             <property name="jmxServiceURL">service:jmx:rmi://127.0.0.1:44444/jndi/rmi://127.0.0.1:1099/karaf-root</property>
             <property name="jmxUsername">admin</property>
             <property name="jmxPassword">admin</property>

--- a/itests/common/src/main/java/io/fabric8/itests/common/BootstrapServiceTest.java
+++ b/itests/common/src/main/java/io/fabric8/itests/common/BootstrapServiceTest.java
@@ -45,7 +45,7 @@ public class BootstrapServiceTest  {
     @Deployment
     @StartLevelAware(autostart = true)
     public static Archive<?> deployment() {
-        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "bootstrap-service-test");
+        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "bootstrap-service-test.jar");
         archive.addPackage(CommandSupport.class.getPackage());
         archive.setManifest(new Asset() {
             @Override

--- a/itests/common/src/main/java/io/fabric8/itests/common/ContainerStartupTest.java
+++ b/itests/common/src/main/java/io/fabric8/itests/common/ContainerStartupTest.java
@@ -57,7 +57,7 @@ public class ContainerStartupTest {
     @Deployment
     @StartLevelAware(autostart = true)
     public static Archive<?> deployment() {
-        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "container-startup-test");
+        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "container-startup-test.jar");
         archive.addClasses(PasswordEncoder.class, Base64Encoder.class);
         archive.addPackage(CommandSupport.class.getPackage());
         archive.setManifest(new Asset() {

--- a/itests/common/src/main/java/io/fabric8/itests/common/FabricCreateCommandTest.java
+++ b/itests/common/src/main/java/io/fabric8/itests/common/FabricCreateCommandTest.java
@@ -56,7 +56,7 @@ public class FabricCreateCommandTest {
     @Deployment
     @StartLevelAware(autostart = true)
     public static Archive<?> deployment() {
-        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "create-command-test");
+        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "create-command-test.jar");
         archive.addClasses(PasswordEncoder.class, Base64Encoder.class);
         archive.addPackage(CommandSupport.class.getPackage());
         archive.setManifest(new Asset() {

--- a/itests/common/src/main/java/io/fabric8/itests/common/ProfileManagementJolokiaTest.java
+++ b/itests/common/src/main/java/io/fabric8/itests/common/ProfileManagementJolokiaTest.java
@@ -40,7 +40,7 @@ public class ProfileManagementJolokiaTest extends AbstractProfileManagementTest 
     
     @BeforeClass
     public static void beforeClass() throws Exception {
-        String jmxServiceURL = "http://localhost:8181/jolokia";
+        String jmxServiceURL = "http://127.0.0.1:8181/jolokia";
         proxy = JolokiaMXBeanProxy.getMXBeanProxy(jmxServiceURL, new ObjectName(ProfileManagement.OBJECT_NAME), ProfileManagement.class, credentials[0], credentials[1]);
     }
 

--- a/itests/common/src/main/java/io/fabric8/itests/common/ProfileManagementProxyTest.java
+++ b/itests/common/src/main/java/io/fabric8/itests/common/ProfileManagementProxyTest.java
@@ -39,7 +39,6 @@ import org.junit.runner.RunWith;
  */
 @RunAsClient
 @RunWith(Arquillian.class)
-@Ignore("[FABRIC-1173] Cannot reliably delete profile version")
 public class ProfileManagementProxyTest extends AbstractProfileManagementTest {
 
     static final String[] credentials = new String[] { "admin", "admin" };

--- a/itests/common/src/main/java/io/fabric8/itests/support/ChildContainerBuilder.java
+++ b/itests/common/src/main/java/io/fabric8/itests/support/ChildContainerBuilder.java
@@ -21,7 +21,7 @@ public class ChildContainerBuilder extends ContainerBuilder<ChildContainerBuilde
 
 
 	protected ChildContainerBuilder(CreateChildContainerOptions.Builder optionsBuilder) {
-		super(optionsBuilder.parent("root").jmxUser("admin").jmxPassword("admin").zookeeperPassword("admin").jvmOpts("-Xmx1536m"));
+		super(optionsBuilder.parent("root").jmxUser("admin").jmxPassword("admin").zookeeperPassword("admin").jvmOpts("-Xmx1536m -Djava.net.preferIPv4Stack=true"));
 	}
 
 	public static ChildContainerBuilder child() {

--- a/itests/paxexam/common/src/main/java/io/fabric8/itests/paxexam/support/ChildContainerBuilder.java
+++ b/itests/paxexam/common/src/main/java/io/fabric8/itests/paxexam/support/ChildContainerBuilder.java
@@ -23,7 +23,7 @@ public class ChildContainerBuilder extends ContainerBuilder<ChildContainerBuilde
 
 
 	protected ChildContainerBuilder(ServiceProxy<FabricService> proxy, CreateChildContainerOptions.Builder optionsBuilder) {
-		super(proxy, optionsBuilder.parent("root").jmxUser("admin").jmxPassword("admin").zookeeperPassword("admin").jvmOpts("-Xmx1536m"));
+		super(proxy, optionsBuilder.parent("root").jmxUser("admin").jmxPassword("admin").zookeeperPassword("admin").jvmOpts("-Xmx1536m -Djava.net.preferIPv4Stack=true"));
 	}
 
 	public static ChildContainerBuilder child(ServiceProxy<FabricService> proxy) {

--- a/itests/paxexam/common/src/main/java/io/fabric8/itests/paxexam/support/FabricTestSupport.java
+++ b/itests/paxexam/common/src/main/java/io/fabric8/itests/paxexam/support/FabricTestSupport.java
@@ -76,7 +76,7 @@ public class FabricTestSupport extends FabricKarafTestSupport {
         if (jvmOpts != null) {
             builder.jvmOpts(jvmOpts);
         } else {
-            builder.jvmOpts("-Xms1024m -Xmx1536m");
+            builder.jvmOpts("-Xms1024m -Xmx1536m -Djava.net.preferIPv4Stack=true");
         }
 
         CreateContainerMetadata[] metadata = fabricService.createContainers(builder.build());

--- a/itests/smoke/karaf/src/test/java/io/fabric8/itests/smoke/karaf/ContainerUpgradeAndRollbackTest.java
+++ b/itests/smoke/karaf/src/test/java/io/fabric8/itests/smoke/karaf/ContainerUpgradeAndRollbackTest.java
@@ -53,7 +53,7 @@ public class ContainerUpgradeAndRollbackTest {
     @Deployment
     @StartLevelAware(autostart = true)
     public static Archive<?> deployment() {
-        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "container-upgrade-rollback-test");
+        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "container-upgrade-rollback-test.jar");
         archive.addPackage(CommandSupport.class.getPackage());
         archive.setManifest(new Asset() {
             @Override

--- a/itests/smoke/karaf/src/test/java/io/fabric8/itests/smoke/karaf/CreateChildContainerTest.java
+++ b/itests/smoke/karaf/src/test/java/io/fabric8/itests/smoke/karaf/CreateChildContainerTest.java
@@ -55,7 +55,7 @@ public class CreateChildContainerTest {
     @Deployment
     @StartLevelAware(autostart = true)
     public static Archive<?> deployment() {
-        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "create-child-test");
+        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "create-child-test.jar");
         archive.addPackage(CommandSupport.class.getPackage());
         archive.setManifest(new Asset() {
             @Override

--- a/itests/smoke/karaf/src/test/java/io/fabric8/itests/smoke/karaf/DeploymentAgentTest.java
+++ b/itests/smoke/karaf/src/test/java/io/fabric8/itests/smoke/karaf/DeploymentAgentTest.java
@@ -59,7 +59,7 @@ public class DeploymentAgentTest {
     @Deployment
     @StartLevelAware(autostart = true)
     public static Archive<?> deployment() {
-        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "deployment-agent-test");
+        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "deployment-agent-test.jar");
         archive.addPackage(CommandSupport.class.getPackage());
         archive.setManifest(new Asset() {
             @Override

--- a/itests/smoke/karaf/src/test/java/io/fabric8/itests/smoke/karaf/EnsembleTest.java
+++ b/itests/smoke/karaf/src/test/java/io/fabric8/itests/smoke/karaf/EnsembleTest.java
@@ -56,7 +56,7 @@ public class EnsembleTest {
     @Deployment
     @StartLevelAware(autostart = true)
     public static Archive<?> deployment() {
-        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "ensemble-test");
+        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "ensemble-test.jar");
         archive.addPackage(CommandSupport.class.getPackage());
         archive.setManifest(new Asset() {
             @Override

--- a/itests/smoke/karaf/src/test/java/io/fabric8/itests/smoke/karaf/JoinTest.java
+++ b/itests/smoke/karaf/src/test/java/io/fabric8/itests/smoke/karaf/JoinTest.java
@@ -51,7 +51,7 @@ public class JoinTest {
     @Deployment
     @StartLevelAware(autostart = true)
     public static Archive<?> deployment() {
-        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "join-test");
+        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "join-test.jar");
         archive.addPackage(CommandSupport.class.getPackage());
         archive.setManifest(new Asset() {
             @Override

--- a/itests/smoke/karaf/src/test/java/io/fabric8/itests/smoke/karaf/ProfileEditTest.java
+++ b/itests/smoke/karaf/src/test/java/io/fabric8/itests/smoke/karaf/ProfileEditTest.java
@@ -48,7 +48,7 @@ public class ProfileEditTest {
     @Deployment
     @StartLevelAware(autostart = true)
     public static Archive<?> deployment() {
-        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "profile-edit-test");
+        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "profile-edit-test.jar");
         archive.addPackage(CommandSupport.class.getPackage());
         archive.setManifest(new Asset() {
             @Override

--- a/itests/smoke/karaf/src/test/resources/arquillian.xml
+++ b/itests/smoke/karaf/src/test/resources/arquillian.xml
@@ -24,7 +24,7 @@
 			<property name="karafHome">${karaf.home}</property>
             <property name="allowConnectingToRunningServer">true</property>
             <property name="bootstrapCompleteService">io.fabric8.api.ZooKeeperClusterBootstrap</property>
-            <property name="javaVmArguments">-Xmx1536m -Dfabric.version=${project.version} -agentlib:jdwp=transport=dt_socket,address=5005,server=y,suspend=n</property>
+            <property name="javaVmArguments">-Xmx1536m -Djava.net.preferIPv4Stack=true -Dfabric.version=${project.version} -agentlib:jdwp=transport=dt_socket,address=5005,server=y,suspend=n</property>
             <property name="jmxServiceURL">service:jmx:rmi://127.0.0.1:44444/jndi/rmi://127.0.0.1:1099/karaf-root</property>
             <property name="jmxUsername">admin</property>
             <property name="jmxPassword">admin</property>


### PR DESCRIPTION
It works well, all tests pass.
From fabric8-maven-plugin POV, this change doesn't break anything, even
better - the plugin receives already configured Aether's
org.eclipse.aether.RepositorySystem object which is then passed to
AetherBasedResolved in fabric-maven classes. This is the right approach,
so everything works fine with both Maven 3.2.3 (which uses Aether
0.9.0.M2) and later Mavens (which use Aether with refactored
connectors/transports)
