### PR TITLE
Configure the surefire plugin with rerunFailingTestsCount=2 to avoid …

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -39,7 +39,7 @@
         <maven-javadoc-plugin-version>2.9.1</maven-javadoc-plugin-version>
         <maven-notices-plugin-version>1.32</maven-notices-plugin-version>
         <maven-bundle-summary-plugin-version>1.34</maven-bundle-summary-plugin-version>
-        <maven-surefire-plugin-version>2.17</maven-surefire-plugin-version>
+        <maven-surefire-plugin-version>2.18.1</maven-surefire-plugin-version>
         <maven-deploy-plugin-version>2.8.1</maven-deploy-plugin-version>
         <maven-shade-plugin-version>2.3</maven-shade-plugin-version>
     </properties>
@@ -234,6 +234,8 @@
                     <useSystemClassLoader>false</useSystemClassLoader>
                     <useManifestOnlyJar>false</useManifestOnlyJar>
                     <failIfNoTests>false</failIfNoTests>
+                    <!-- The number of times each failing test will be rerun. -->
+                    <rerunFailingTestsCount>2</rerunFailingTestsCount>
                     <runOrder>alphabetical</runOrder>
                     <systemPropertyVariables>
                         <basedir>${basedir}</basedir>


### PR DESCRIPTION
…failing on flaky tests.
