### PR TITLE
ENTESB-4269 Camel / Fabric8 features should use servicemix-specs for jsr311-api

### DIFF
--- a/fabric/fabric8-karaf/src/main/resources/fabric-features.xml
+++ b/fabric/fabric8-karaf/src/main/resources/fabric-features.xml
@@ -102,7 +102,7 @@
     </feature>
 
     <feature name="jsr-311" version="${project.version}">
-        <bundle>mvn:javax.ws.rs/jsr311-api/1.1.1</bundle>
+        <bundle dependency='true'>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jsr311-api-1.1.1/${jsr311-api-smx-version}</bundle>
     </feature>
 
     <feature name="fabric-zookeeper" version="${project.version}" resolver="(obr)">

--- a/pom.xml
+++ b/pom.xml
@@ -272,6 +272,7 @@
         <jsch-version>0.1.51</jsch-version>
         <jsch-smx-version>0.1.51_1</jsch-smx-version>
         <json4s-version>3.2.4_1</json4s-version>
+        <jsr311-api-smx-version>2.5.0</jsr311-api-smx-version>
         <junit-version>4.11</junit-version>
         <karaf-version>2.4.0.redhat-621069</karaf-version>
         <libvirt-bundle-version>1.1</libvirt-bundle-version>


### PR DESCRIPTION
https://issues.jboss.org/browse/ENTESB-4269
