### PR TITLE
track down intermittent failure of ServiceFactoryTest. Root cause was…

### DIFF
--- a/fabric/fabric-groups/pom.xml
+++ b/fabric/fabric-groups/pom.xml
@@ -72,6 +72,13 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/fabric/fabric-groups/src/main/java/io/fabric8/groups/NodeState.java
+++ b/fabric/fabric-groups/src/main/java/io/fabric8/groups/NodeState.java
@@ -30,6 +30,9 @@ public class NodeState {
     @JsonProperty
     public final String container;
 
+    @JsonProperty
+    public String uuid; // internal use to suppress duplicates
+
     public NodeState() {
         this(null);
     }

--- a/mq/mq-fabric/src/main/java/io/fabric8/mq/fabric/ActiveMQServiceFactory.java
+++ b/mq/mq-fabric/src/main/java/io/fabric8/mq/fabric/ActiveMQServiceFactory.java
@@ -561,6 +561,7 @@ public class ActiveMQServiceFactory  {
         }
 
         public void close() throws Exception {
+            LOG.debug(this + " close");
             synchronized (ActiveMQServiceFactory.this) {
                 if (pool_enabled) {
                     return_pool(this);
@@ -631,6 +632,7 @@ public class ActiveMQServiceFactory  {
                 if (server != null && server.broker != null) {
                     // slave blocked on store lock
                     try {
+                        LOG.debug("sync broker.stop()");
                         server.broker.stop();
                     } catch (Exception e) {
                         LOG.warn("Call to stop failed with exception:" + e.getLocalizedMessage());
@@ -677,6 +679,7 @@ public class ActiveMQServiceFactory  {
                                 @Override
                                 public void groupEvent(Group<ActiveMQNode> group, GroupEvent event) {
                                     try {
+                                        LOG.trace("Event:" + event + ", started:" + started.get());
                                         if (event.equals(GroupEvent.CONNECTED) || event.equals(GroupEvent.CHANGED)) {
                                             if (discoveryAgent.getGroup().isMaster(name)) {
                                                 if (started.compareAndSet(false, true)) {

--- a/mq/mq-fabric/src/test/resources/log4j.properties
+++ b/mq/mq-fabric/src/test/resources/log4j.properties
@@ -20,7 +20,9 @@
 #
 log4j.rootLogger=INFO, out
 
-log4j.logger.io.fabric=INFO
+#log4j.logger.io.fabric8.mq.fabric=DEBUG
+#log4j.logger.org.apache.zookeeper=TRACE
+#log4j.logger.io.fabric8.groups=TRACE
 
 log4j.appender.out=org.apache.log4j.ConsoleAppender
 log4j.appender.out.layout=org.apache.log4j.PatternLayout


### PR DESCRIPTION
… partial sequential ephemeral node creation leading to duplicate state and conditional guarantee delete rather than letting curator take care of reconnect. Fix is to use hidden uuid nodestate field on znode creation such that duplicates can be suppressed. This avoids a backward comp issue with the sequence comparator if the znode path was updated to include the uuid in line with the zk recipe for sequential ephemeral
