### PR TITLE
Entesb 4431

### DIFF
--- a/fabric/fabric-groups/pom.xml
+++ b/fabric/fabric-groups/pom.xml
@@ -72,13 +72,6 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <scope>test</scope>
-        </dependency>
-
     </dependencies>
 
     <build>

--- a/fabric/fabric-groups/src/main/java/io/fabric8/groups/NodeState.java
+++ b/fabric/fabric-groups/src/main/java/io/fabric8/groups/NodeState.java
@@ -30,9 +30,6 @@ public class NodeState {
     @JsonProperty
     public final String container;
 
-    @JsonProperty
-    public String uuid; // internal use to suppress duplicates
-
     public NodeState() {
         this(null);
     }

--- a/fabric/fabric-groups/src/main/java/io/fabric8/groups/internal/ZooKeeperGroup.java
+++ b/fabric/fabric-groups/src/main/java/io/fabric8/groups/internal/ZooKeeperGroup.java
@@ -80,7 +80,6 @@ public class ZooKeeperGroup<T extends NodeState> implements Group<T> {
     private final AtomicBoolean started = new AtomicBoolean();
     private final AtomicBoolean connected = new AtomicBoolean();
     protected final SequenceComparator sequenceComparator = new SequenceComparator();
-    private final String uuid = UUID.randomUUID().toString();
 
     private volatile String id;
     private volatile T state;
@@ -172,7 +171,6 @@ public class ZooKeeperGroup<T extends NodeState> implements Group<T> {
      */
     @Override
     public void close() throws IOException {
-        LOG.debug(this + ".close, connected:" + connected);
         if (started.compareAndSet(true, false)) {
             client.getConnectionStateListenable().removeListener(connectionStateListener);
             executorService.shutdownNow();
@@ -182,8 +180,8 @@ public class ZooKeeperGroup<T extends NodeState> implements Group<T> {
                 throw (IOException) new InterruptedIOException().initCause(e);
             }
             try {
-                doUpdate(null);
                 if (isConnected()) {
+                    doUpdate(null);
                     callListeners(GroupListener.GroupEvent.DISCONNECTED);
                 }
             } catch (Exception e) {
@@ -225,50 +223,30 @@ public class ZooKeeperGroup<T extends NodeState> implements Group<T> {
     }
 
     protected void doUpdate(T state) throws Exception {
-        LOG.trace(this + " doUpdate, state:" + state + " id:" + id);
-        if (state == null) {
-            if (id != null) {
-                try {
-                    client.delete().guaranteed().forPath(id);
-                } catch (KeeperException.NoNodeException e) {
-                    // Ignore
-                } finally {
-                    id = null;
+        if (isConnected()) {
+            if (state == null) {
+                if (id != null) {
+                    try {
+                        client.delete().guaranteed().forPath(id);
+                    } catch (KeeperException.NoNodeException e) {
+                        // Ignore
+                    } finally {
+                        id = null;
+                    }
                 }
-            }
-        } else if (isConnected()) {
-            if (id == null) {
-                id = createEphemeralNode(state);
             } else {
-                try {
-                    client.setData().forPath(id, encode(state));
-                } catch (KeeperException.NoNodeException e) {
-                    id = createEphemeralNode(state);
-                }
-            }
-        }
-    }
-
-    private String createEphemeralNode(T state) throws Exception {
-        state.uuid = uuid;
-        String pathId = client.create().creatingParentsIfNeeded()
-            .withMode(CreateMode.EPHEMERAL_SEQUENTIAL)
-            .forPath(path + "/0", encode(state));
-        LOG.trace(this + ", state:" + state + ", new ephemeralSequential path:" + pathId);
-        prunePartialState(state, pathId);
-        state.uuid = null;
-        return pathId;
-    }
-
-    // remove ephemeral sequential nodes created on server but not visible on client
-    private void prunePartialState(final T ourState, final String pathId) throws Exception {
-        if (ourState.uuid != null) {
-            clearAndRefresh(true, true);
-            List<ChildData<T>> children = new ArrayList<ChildData<T>>(currentData.values());
-            for (ChildData<T> child : children) {
-                if (ourState.uuid.equals(child.getNode().uuid) && !child.getPath().equals(pathId)) {
-                    LOG.debug("Deleting partially created znode: " + child.getPath());
-                    client.delete().guaranteed().forPath(child.getPath());
+                if (id == null) {
+                    id = client.create().creatingParentsIfNeeded()
+                        .withMode(CreateMode.EPHEMERAL_SEQUENTIAL)
+                        .forPath(path + "/0", encode(state));
+                } else {
+                    try {
+                        client.setData().forPath(id, encode(state));
+                    } catch (KeeperException.NoNodeException e) {
+                        id = client.create().creatingParentsIfNeeded()
+                                .withMode(CreateMode.EPHEMERAL_SEQUENTIAL)
+                                .forPath(path + "/0", encode(state));
+                    }
                 }
             }
         }

--- a/fabric/fabric-groups/src/main/java/io/fabric8/groups/internal/ZooKeeperGroup.java
+++ b/fabric/fabric-groups/src/main/java/io/fabric8/groups/internal/ZooKeeperGroup.java
@@ -15,6 +15,7 @@
  */
 package io.fabric8.groups.internal;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
@@ -64,7 +65,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public class ZooKeeperGroup<T extends NodeState> implements Group<T> {
 
-    static public final ObjectMapper MAPPER = new ObjectMapper();
+    static public final ObjectMapper MAPPER = new ObjectMapper().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 
     static private final Logger LOG = LoggerFactory.getLogger(ZooKeeperGroup.class);
 
@@ -550,10 +551,9 @@ public class ZooKeeperGroup<T extends NodeState> implements Group<T> {
     public static <T> Map<String, T> members(CuratorFramework curator, String path, Class<T> clazz) throws Exception {
         Map<String, T> map = new TreeMap<String, T>();
         List<String> nodes = curator.getChildren().forPath(path);
-        ObjectMapper mapper = new ObjectMapper();
         for (String node : nodes) {
             byte[] data = curator.getData().forPath(path + "/" + node);
-            T val = mapper.readValue(data, clazz);
+            T val = MAPPER.readValue(data, clazz);
             map.put(node, val);
         }
         return map;

--- a/fabric/fabric-groups/src/test/java/io/fabric8/groups/GroupTest.java
+++ b/fabric/fabric-groups/src/test/java/io/fabric8/groups/GroupTest.java
@@ -28,7 +28,6 @@ import org.junit.Test;
 
 import java.io.File;
 import java.net.ServerSocket;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -75,61 +74,6 @@ public class GroupTest {
         cnxnFactory.configure(cfg.getClientPortAddress(), cfg.getMaxClientCnxns());
         cnxnFactory.startup(zkServer);
         return cnxnFactory;
-    }
-
-
-    @Test
-    public void testOrder() throws Exception {
-        int port = findFreePort();
-
-        CuratorFramework curator = CuratorFrameworkFactory.builder()
-                .connectString("localhost:" + port)
-                .retryPolicy(new RetryNTimes(10, 100))
-                .build();
-        curator.start();
-
-
-        final String path = "/singletons/test/Order" + System.currentTimeMillis();
-        ArrayList<ZooKeeperGroup> members = new ArrayList<ZooKeeperGroup>();
-        for (int i=0;i<4;i++) {
-            ZooKeeperGroup<NodeState> group = new ZooKeeperGroup<NodeState>(curator, path, NodeState.class);
-            group.add(listener);
-            members.add(group);
-        }
-
-        for (ZooKeeperGroup group : members) {
-            assertFalse(group.isConnected());
-            assertFalse(group.isMaster());
-        }
-
-        NIOServerCnxnFactory cnxnFactory = startZooKeeper(port);
-
-        curator.getZookeeperClient().blockUntilConnectedOrTimedOut();
-
-        // first to start should be master if members are ordered...
-        int i=0;
-        for (ZooKeeperGroup group : members) {
-            group.start();
-            group.update(new NodeState("foo" + i));
-            i++;
-
-            // wait for registration
-            while (group.getId() == null) {
-                TimeUnit.MILLISECONDS.sleep(100);
-            }
-        }
-
-        boolean firsStartedIsMaster = members.get(0).isMaster();
-
-        for (ZooKeeperGroup group : members) {
-            group.close();
-        }
-        curator.close();
-        cnxnFactory.shutdown();
-        cnxnFactory.join();
-
-        assertTrue("first started is master", firsStartedIsMaster);
-
     }
 
     @Test

--- a/mq/mq-fabric/src/main/java/io/fabric8/mq/fabric/ActiveMQServiceFactory.java
+++ b/mq/mq-fabric/src/main/java/io/fabric8/mq/fabric/ActiveMQServiceFactory.java
@@ -561,7 +561,6 @@ public class ActiveMQServiceFactory  {
         }
 
         public void close() throws Exception {
-            LOG.debug(this + " close");
             synchronized (ActiveMQServiceFactory.this) {
                 if (pool_enabled) {
                     return_pool(this);
@@ -632,7 +631,6 @@ public class ActiveMQServiceFactory  {
                 if (server != null && server.broker != null) {
                     // slave blocked on store lock
                     try {
-                        LOG.debug("sync broker.stop()");
                         server.broker.stop();
                     } catch (Exception e) {
                         LOG.warn("Call to stop failed with exception:" + e.getLocalizedMessage());
@@ -679,7 +677,6 @@ public class ActiveMQServiceFactory  {
                                 @Override
                                 public void groupEvent(Group<ActiveMQNode> group, GroupEvent event) {
                                     try {
-                                        LOG.trace("Event:" + event + ", started:" + started.get());
                                         if (event.equals(GroupEvent.CONNECTED) || event.equals(GroupEvent.CHANGED)) {
                                             if (discoveryAgent.getGroup().isMaster(name)) {
                                                 if (started.compareAndSet(false, true)) {

--- a/mq/mq-fabric/src/test/java/io/fabric8/mq/fabric/ServiceFactoryTest.java
+++ b/mq/mq-fabric/src/test/java/io/fabric8/mq/fabric/ServiceFactoryTest.java
@@ -64,7 +64,6 @@ public class ServiceFactoryTest {
 
         CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder()
                 .connectString("localhost:" + zkPort)
-                .sessionTimeoutMs(5000)
                 .retryPolicy(new RetryNTimes(5000, 1000));
 
         curator = builder.build();
@@ -123,7 +122,7 @@ public class ServiceFactoryTest {
 
             underTest.deleted("b");
 
-            assertTrue("Broker stopped - failover transport interrupted", interrupted.await(5, TimeUnit.SECONDS));
+            assertTrue("Broker stopped - transport interrupted", interrupted.await(5, TimeUnit.SECONDS));
 
             connection.close();
         }
@@ -131,10 +130,7 @@ public class ServiceFactoryTest {
 
     @Test
     public void testZkDisconnectFastReconnect() throws Exception {
-        for (int i=0;i<10;i++) {
-            LOG.info("testZkDisconnectFastReconnect - Iteration:" + i);
-            doTestZkDisconnectFastReconnect(false);
-        }
+        doTestZkDisconnectFastReconnect(false);
     }
 
     @Test
@@ -165,7 +161,7 @@ public class ServiceFactoryTest {
 
                 if (waitForInitalconnect) {
                     try {
-                        connected.await(15, TimeUnit.SECONDS);
+                        connected.await(5, TimeUnit.SECONDS);
                     } catch (InterruptedException e) {
                         e.printStackTrace();
                     }
@@ -188,7 +184,7 @@ public class ServiceFactoryTest {
             @Override
             public void run() {
                 try {
-                    ActiveMQConnectionFactory cf = new ActiveMQConnectionFactory("failover:(tcp://localhost:61616)?useExponentialBackOff=false&initialReconnectDelay=500");
+                    ActiveMQConnectionFactory cf = new ActiveMQConnectionFactory("failover:(tcp://localhost:61616)?useExponentialBackOff=false");
 
                     amqConnection[0] = (ActiveMQConnection) cf.createConnection();
 
@@ -207,13 +203,13 @@ public class ServiceFactoryTest {
 
         underTest.updated("b", props);
 
-        assertTrue("zk closeAll complete", zkInterruptionComplete.await(60, TimeUnit.SECONDS));
+        assertTrue("zk closeAll complete", zkInterruptionComplete.await(20, TimeUnit.SECONDS));
 
         LOG.info("Zk close all done!");
 
-        assertTrue("was connected", connected.await(15, TimeUnit.SECONDS));
+        assertTrue("was connected", connected.await(20, TimeUnit.SECONDS));
 
-        for (int i = 0; i < 30; i++) {
+        for (int i = 0; i < 20; i++) {
             LOG.info("Checking for connection...");
             if (amqConnection[0].getTransport().isConnected()) {
                 break;

--- a/mq/mq-fabric/src/test/resources/log4j.properties
+++ b/mq/mq-fabric/src/test/resources/log4j.properties
@@ -20,9 +20,7 @@
 #
 log4j.rootLogger=INFO, out
 
-#log4j.logger.io.fabric8.mq.fabric=DEBUG
-#log4j.logger.org.apache.zookeeper=TRACE
-#log4j.logger.io.fabric8.groups=TRACE
+log4j.logger.io.fabric=INFO
 
 log4j.appender.out=org.apache.log4j.ConsoleAppender
 log4j.appender.out.layout=org.apache.log4j.PatternLayout


### PR DESCRIPTION
revert use of uuid field to suppress duplicates. disable fail on unknown properties such that fix can be introduced in a later revision
