### PR TITLE
Revert "Revert "track down intermittent failure of ServiceFactoryTest…

### DIFF
--- a/fabric/fabric-groups/pom.xml
+++ b/fabric/fabric-groups/pom.xml
@@ -72,6 +72,13 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/fabric/fabric-groups/src/main/java/io/fabric8/groups/NodeState.java
+++ b/fabric/fabric-groups/src/main/java/io/fabric8/groups/NodeState.java
@@ -30,6 +30,9 @@ public class NodeState {
     @JsonProperty
     public final String container;
 
+    @JsonProperty
+    public String uuid; // internal use to suppress duplicates
+
     public NodeState() {
         this(null);
     }

--- a/fabric/fabric-groups/src/main/java/io/fabric8/groups/internal/ZooKeeperGroup.java
+++ b/fabric/fabric-groups/src/main/java/io/fabric8/groups/internal/ZooKeeperGroup.java
@@ -80,6 +80,7 @@ public class ZooKeeperGroup<T extends NodeState> implements Group<T> {
     private final AtomicBoolean started = new AtomicBoolean();
     private final AtomicBoolean connected = new AtomicBoolean();
     protected final SequenceComparator sequenceComparator = new SequenceComparator();
+    private final String uuid = UUID.randomUUID().toString();
 
     private volatile String id;
     private volatile T state;
@@ -171,6 +172,7 @@ public class ZooKeeperGroup<T extends NodeState> implements Group<T> {
      */
     @Override
     public void close() throws IOException {
+        LOG.debug(this + ".close, connected:" + connected);
         if (started.compareAndSet(true, false)) {
             client.getConnectionStateListenable().removeListener(connectionStateListener);
             executorService.shutdownNow();
@@ -180,8 +182,8 @@ public class ZooKeeperGroup<T extends NodeState> implements Group<T> {
                 throw (IOException) new InterruptedIOException().initCause(e);
             }
             try {
+                doUpdate(null);
                 if (isConnected()) {
-                    doUpdate(null);
                     callListeners(GroupListener.GroupEvent.DISCONNECTED);
                 }
             } catch (Exception e) {
@@ -223,30 +225,50 @@ public class ZooKeeperGroup<T extends NodeState> implements Group<T> {
     }
 
     protected void doUpdate(T state) throws Exception {
-        if (isConnected()) {
-            if (state == null) {
-                if (id != null) {
-                    try {
-                        client.delete().guaranteed().forPath(id);
-                    } catch (KeeperException.NoNodeException e) {
-                        // Ignore
-                    } finally {
-                        id = null;
-                    }
+        LOG.trace(this + " doUpdate, state:" + state + " id:" + id);
+        if (state == null) {
+            if (id != null) {
+                try {
+                    client.delete().guaranteed().forPath(id);
+                } catch (KeeperException.NoNodeException e) {
+                    // Ignore
+                } finally {
+                    id = null;
                 }
+            }
+        } else if (isConnected()) {
+            if (id == null) {
+                id = createEphemeralNode(state);
             } else {
-                if (id == null) {
-                    id = client.create().creatingParentsIfNeeded()
-                        .withMode(CreateMode.EPHEMERAL_SEQUENTIAL)
-                        .forPath(path + "/0", encode(state));
-                } else {
-                    try {
-                        client.setData().forPath(id, encode(state));
-                    } catch (KeeperException.NoNodeException e) {
-                        id = client.create().creatingParentsIfNeeded()
-                                .withMode(CreateMode.EPHEMERAL_SEQUENTIAL)
-                                .forPath(path + "/0", encode(state));
-                    }
+                try {
+                    client.setData().forPath(id, encode(state));
+                } catch (KeeperException.NoNodeException e) {
+                    id = createEphemeralNode(state);
+                }
+            }
+        }
+    }
+
+    private String createEphemeralNode(T state) throws Exception {
+        state.uuid = uuid;
+        String pathId = client.create().creatingParentsIfNeeded()
+            .withMode(CreateMode.EPHEMERAL_SEQUENTIAL)
+            .forPath(path + "/0", encode(state));
+        LOG.trace(this + ", state:" + state + ", new ephemeralSequential path:" + pathId);
+        prunePartialState(state, pathId);
+        state.uuid = null;
+        return pathId;
+    }
+
+    // remove ephemeral sequential nodes created on server but not visible on client
+    private void prunePartialState(final T ourState, final String pathId) throws Exception {
+        if (ourState.uuid != null) {
+            clearAndRefresh(true, true);
+            List<ChildData<T>> children = new ArrayList<ChildData<T>>(currentData.values());
+            for (ChildData<T> child : children) {
+                if (ourState.uuid.equals(child.getNode().uuid) && !child.getPath().equals(pathId)) {
+                    LOG.debug("Deleting partially created znode: " + child.getPath());
+                    client.delete().guaranteed().forPath(child.getPath());
                 }
             }
         }

--- a/fabric/fabric-groups/src/test/java/io/fabric8/groups/GroupTest.java
+++ b/fabric/fabric-groups/src/test/java/io/fabric8/groups/GroupTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.net.ServerSocket;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -74,6 +75,61 @@ public class GroupTest {
         cnxnFactory.configure(cfg.getClientPortAddress(), cfg.getMaxClientCnxns());
         cnxnFactory.startup(zkServer);
         return cnxnFactory;
+    }
+
+
+    @Test
+    public void testOrder() throws Exception {
+        int port = findFreePort();
+
+        CuratorFramework curator = CuratorFrameworkFactory.builder()
+                .connectString("localhost:" + port)
+                .retryPolicy(new RetryNTimes(10, 100))
+                .build();
+        curator.start();
+
+
+        final String path = "/singletons/test/Order" + System.currentTimeMillis();
+        ArrayList<ZooKeeperGroup> members = new ArrayList<ZooKeeperGroup>();
+        for (int i=0;i<4;i++) {
+            ZooKeeperGroup<NodeState> group = new ZooKeeperGroup<NodeState>(curator, path, NodeState.class);
+            group.add(listener);
+            members.add(group);
+        }
+
+        for (ZooKeeperGroup group : members) {
+            assertFalse(group.isConnected());
+            assertFalse(group.isMaster());
+        }
+
+        NIOServerCnxnFactory cnxnFactory = startZooKeeper(port);
+
+        curator.getZookeeperClient().blockUntilConnectedOrTimedOut();
+
+        // first to start should be master if members are ordered...
+        int i=0;
+        for (ZooKeeperGroup group : members) {
+            group.start();
+            group.update(new NodeState("foo" + i));
+            i++;
+
+            // wait for registration
+            while (group.getId() == null) {
+                TimeUnit.MILLISECONDS.sleep(100);
+            }
+        }
+
+        boolean firsStartedIsMaster = members.get(0).isMaster();
+
+        for (ZooKeeperGroup group : members) {
+            group.close();
+        }
+        curator.close();
+        cnxnFactory.shutdown();
+        cnxnFactory.join();
+
+        assertTrue("first started is master", firsStartedIsMaster);
+
     }
 
     @Test

--- a/mq/mq-fabric/src/main/java/io/fabric8/mq/fabric/ActiveMQServiceFactory.java
+++ b/mq/mq-fabric/src/main/java/io/fabric8/mq/fabric/ActiveMQServiceFactory.java
@@ -561,6 +561,7 @@ public class ActiveMQServiceFactory  {
         }
 
         public void close() throws Exception {
+            LOG.debug(this + " close");
             synchronized (ActiveMQServiceFactory.this) {
                 if (pool_enabled) {
                     return_pool(this);
@@ -631,6 +632,7 @@ public class ActiveMQServiceFactory  {
                 if (server != null && server.broker != null) {
                     // slave blocked on store lock
                     try {
+                        LOG.debug("sync broker.stop()");
                         server.broker.stop();
                     } catch (Exception e) {
                         LOG.warn("Call to stop failed with exception:" + e.getLocalizedMessage());
@@ -677,6 +679,7 @@ public class ActiveMQServiceFactory  {
                                 @Override
                                 public void groupEvent(Group<ActiveMQNode> group, GroupEvent event) {
                                     try {
+                                        LOG.trace("Event:" + event + ", started:" + started.get());
                                         if (event.equals(GroupEvent.CONNECTED) || event.equals(GroupEvent.CHANGED)) {
                                             if (discoveryAgent.getGroup().isMaster(name)) {
                                                 if (started.compareAndSet(false, true)) {

--- a/mq/mq-fabric/src/test/resources/log4j.properties
+++ b/mq/mq-fabric/src/test/resources/log4j.properties
@@ -20,7 +20,9 @@
 #
 log4j.rootLogger=INFO, out
 
-log4j.logger.io.fabric=INFO
+#log4j.logger.io.fabric8.mq.fabric=DEBUG
+#log4j.logger.org.apache.zookeeper=TRACE
+#log4j.logger.io.fabric8.groups=TRACE
 
 log4j.appender.out=org.apache.log4j.ConsoleAppender
 log4j.appender.out.layout=org.apache.log4j.PatternLayout


### PR DESCRIPTION
…. Root cause was partial sequential ephemeral node creation leading to duplicate state and conditional guarantee delete rather than letting curator take care of reconnect. Fix is to use hidden uuid nodestate field on znode creation such that duplicates can be suppressed""

This reverts commit be5e23cfacc011db55f858ccf989e817728c015e.

https://issues.jboss.org/browse/ENTESB-4437 - good for 6.3 - 6.2.1 will ignore missing json fields
