### PR TITLE
ENTESB-4508 - Maven Repos config. Removed too strict validation.

### DIFF
--- a/fabric/fabric-maven/src/main/java/io/fabric8/maven/util/MavenRepositoryURL.java
+++ b/fabric/fabric-maven/src/main/java/io/fabric8/maven/util/MavenRepositoryURL.java
@@ -90,7 +90,9 @@ public class MavenRepositoryURL
     public MavenRepositoryURL( final String repositorySpec )
         throws MalformedURLException
     {
-        NullArgumentException.validateNotEmpty( repositorySpec, true, "Repository spec" );
+        if( repositorySpec == null || "".equals(repositorySpec.trim()) ){
+            LOG.info("Repository spec is empty. Configuration will fall back to the content of maven xml settngs.");
+        }
 
         final String[] segments = repositorySpec.split( ServiceConstants.SEPARATOR_OPTIONS );
         final StringBuilder urlBuilder = new StringBuilder();


### PR DESCRIPTION
This is to support scenarios where no repo is specified in line, but they are provided inside a settings.xml.

ex.

```
profile-edit --pid io.fabric8.agent/org.ops4j.pax.url.mvn.settings='file:///opt/rh/s.xml' default
profile-edit --pid io.fabric8.agent/org.ops4j.pax.url.mvn.repositories=''  default
```
