### PR TITLE
[ENTESB-4862] Switch to fabric8 gitective 0.9.11 and upgrade Jgit to …

### DIFF
--- a/fabric/fabric-git/pom.xml
+++ b/fabric/fabric-git/pom.xml
@@ -71,7 +71,7 @@
             <version>${jsch-version}</version>
         </dependency>
         <dependency>
-            <groupId>org.gitective</groupId>
+            <groupId>io.fabric8</groupId>
             <artifactId>gitective-core</artifactId>
             <version>${gitective-version}</version>
             <exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,7 @@
         <geronimo-servlet.version>1.2</geronimo-servlet.version>
         <geronimo-ws-metadata.version>1.1.3</geronimo-ws-metadata.version>
         <geronimo-atinject.version>1.0</geronimo-atinject.version>
-        <gitective-version>0.9.9</gitective-version>
+        <gitective-version>0.9.11</gitective-version>
         <gson-version>2.3</gson-version>
         <groovy1-version>1.8.6</groovy1-version>
         <groovy-version>2.4.4</groovy-version>
@@ -261,7 +261,7 @@
         <jetty-plugin-groupId>org.mortbay.jetty</jetty-plugin-groupId>
         <jetty-plugin-version>9.2.14.v20151106</jetty-plugin-version>
         <jetty-version>9.2.14.v20151106</jetty-version>
-        <jgit-version>4.1.0.201509280440-r</jgit-version>
+        <jgit-version>4.1.1.201511131810-r</jgit-version>
         <jledit.version>0.2.1</jledit.version>
         <jline.version>2.12.1.redhat-001</jline.version>
         <jmdns-version>3.4.1</jmdns-version>


### PR DESCRIPTION
…version 4.1.1.201511131810-r

This should make the situation a little bit more clear between gitective and jgit versions.

Andrea
