### PR TITLE
[ENTESB-4443] Upgrade eventadmin to 1.4.6 to prevent NPE when logging…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@
         <exec-maven-plugin-version>1.2.1</exec-maven-plugin-version>
         <felix.bundlerepository.version>2.0.4</felix.bundlerepository.version>
         <felix-configadmin-version>1.8.4</felix-configadmin-version>
-        <felix-eventadmin-version>1.4.2</felix-eventadmin-version>
+        <felix-eventadmin-version>1.4.6</felix-eventadmin-version>
         <felix-fileinstall-version>3.5.0</felix-fileinstall-version>
         <felix-framework-security-version>2.4.0</felix-framework-security-version>
         <felix-framework-version>4.4.1</felix-framework-version>


### PR DESCRIPTION
… null message (e.g., from Camel route)
