### PR TITLE
Add option to indent requirements-export output

### DIFF
--- a/fabric/fabric-commands/src/main/java/io/fabric8/commands/RequirementsExportAction.java
+++ b/fabric/fabric-commands/src/main/java/io/fabric8/commands/RequirementsExportAction.java
@@ -20,6 +20,7 @@ import io.fabric8.api.FabricService;
 import io.fabric8.internal.RequirementsJson;
 import org.apache.felix.gogo.commands.Argument;
 import org.apache.felix.gogo.commands.Command;
+import org.apache.felix.gogo.commands.Option;
 import org.apache.karaf.shell.console.AbstractAction;
 
 import java.io.File;
@@ -27,6 +28,8 @@ import java.io.FileOutputStream;
 
 @Command(name = RequirementsExport.FUNCTION_VALUE, scope = RequirementsExport.SCOPE_VALUE, description = RequirementsExport.DESCRIPTION)
 public class RequirementsExportAction extends AbstractAction {
+    @Option(name = "-i", aliases = {"--indent"}, multiValued = false, required = false, description = "Indent JSON output")
+    protected boolean indent = false;
     @Argument(index = 0, required = true, description = "Output file name")
     protected File outputFile;
 
@@ -45,7 +48,7 @@ public class RequirementsExportAction extends AbstractAction {
         outputFile.getParentFile().mkdirs();
 
         FabricRequirements requirements = getFabricService().getRequirements();
-        RequirementsJson.writeRequirements(new FileOutputStream(outputFile), requirements);
+        RequirementsJson.writeRequirements(new FileOutputStream(outputFile), requirements, indent);
         System.out.println("Exported the fabric requirements to " + outputFile.getCanonicalPath());
         return null;
     }

--- a/fabric/fabric-core/src/main/java/io/fabric8/internal/RequirementsJson.java
+++ b/fabric/fabric-core/src/main/java/io/fabric8/internal/RequirementsJson.java
@@ -17,6 +17,7 @@ package io.fabric8.internal;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import io.fabric8.api.AutoScaleStatus;
 import io.fabric8.api.FabricRequirements;
 import org.slf4j.Logger;
@@ -46,10 +47,15 @@ public final class RequirementsJson {
         return mapper;
     }
 
-    public static void writeRequirements(OutputStream out, FabricRequirements value) throws IOException {
-        mapper.writeValue(out, value);
+    public static void writeRequirements(OutputStream out, FabricRequirements value, boolean indent) throws IOException {
+        if (!mapper.isEnabled(SerializationFeature.INDENT_OUTPUT) && indent) {
+            mapper.enable(SerializationFeature.INDENT_OUTPUT);
+            mapper.writeValue(out, value);
+            mapper.disable(SerializationFeature.INDENT_OUTPUT);
+        } else {
+            mapper.writeValue(out, value);
+        }
     }
-
 
     public static String toJSON(FabricRequirements value) throws IOException {
         return valueToJSON(value);


### PR DESCRIPTION
This PR adds an option to indent the JSON output of requirements-export command.

```
JBossFuse:karaf@dev> requirements-export --help
DESCRIPTION
        fabric:requirements-export

        Exports the current requirements metadata to a JSON file

SYNTAX
        fabric:requirements-export [options] outputFile

ARGUMENTS
        outputFile
                Output file name

OPTIONS
        -i, --indent
                Indent JSON output
        --help
                Display this help message
```

This will ease reading and diffing of the exported file without extra formatting steps.
