### PR TITLE
fixes #ENTESB-5041

### DIFF
--- a/fabric/fabric-commands/src/main/java/io/fabric8/commands/RequirementsExportAction.java
+++ b/fabric/fabric-commands/src/main/java/io/fabric8/commands/RequirementsExportAction.java
@@ -18,15 +18,21 @@ package io.fabric8.commands;
 import io.fabric8.api.FabricRequirements;
 import io.fabric8.api.FabricService;
 import io.fabric8.internal.RequirementsJson;
-import org.apache.felix.gogo.commands.Argument;
-import org.apache.felix.gogo.commands.Command;
-import org.apache.karaf.shell.console.AbstractAction;
 
 import java.io.File;
 import java.io.FileOutputStream;
 
+import org.apache.felix.gogo.commands.Argument;
+import org.apache.felix.gogo.commands.Command;
+import org.apache.felix.gogo.commands.Option;
+import org.apache.karaf.shell.console.AbstractAction;
+
 @Command(name = RequirementsExport.FUNCTION_VALUE, scope = RequirementsExport.SCOPE_VALUE, description = RequirementsExport.DESCRIPTION)
 public class RequirementsExportAction extends AbstractAction {
+	
+	@Option(name="--indent",aliases="--i",description="Indents the output file",required=false)
+	protected String indent;
+	
     @Argument(index = 0, required = true, description = "Output file name")
     protected File outputFile;
 
@@ -43,8 +49,18 @@ public class RequirementsExportAction extends AbstractAction {
     @Override
     protected Object doExecute() throws Exception {
         outputFile.getParentFile().mkdirs();
-
+        
         FabricRequirements requirements = getFabricService().getRequirements();
+        if (Boolean.valueOf(this.indent)) {
+    		
+			RequirementsJson.writeRequirements(
+					new FileOutputStream(outputFile), requirements,
+					true);
+		} else {
+			
+			RequirementsJson.writeRequirements(
+					new FileOutputStream(outputFile), requirements);
+		}
         RequirementsJson.writeRequirements(new FileOutputStream(outputFile), requirements);
         System.out.println("Exported the fabric requirements to " + outputFile.getCanonicalPath());
         return null;

--- a/fabric/fabric-core/src/main/java/io/fabric8/internal/RequirementsJson.java
+++ b/fabric/fabric-core/src/main/java/io/fabric8/internal/RequirementsJson.java
@@ -50,8 +50,17 @@ public final class RequirementsJson {
     }
 
     public static void writeRequirements(OutputStream out, FabricRequirements value) throws IOException {
+    	writeRequirements(out,value,false);
+    }
+
+    public static void writeRequirements(OutputStream out, FabricRequirements value,boolean indent) throws IOException {
     	//ENTESB-5041 : fabric:requirements-export" command to indent requirements-export json output
-    	mapper.enable(SerializationFeature.INDENT_OUTPUT);
+    	if(indent){
+    		mapper.enable(SerializationFeature.INDENT_OUTPUT);		
+    	}else{
+    		
+    		 mapper.disable(SerializationFeature.INDENT_OUTPUT);
+    	}
         mapper.writeValue(out, value);
     }
 

--- a/fabric/fabric-core/src/main/java/io/fabric8/internal/RequirementsJson.java
+++ b/fabric/fabric-core/src/main/java/io/fabric8/internal/RequirementsJson.java
@@ -17,8 +17,11 @@ package io.fabric8.internal;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
 import io.fabric8.api.AutoScaleStatus;
 import io.fabric8.api.FabricRequirements;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,6 +50,8 @@ public final class RequirementsJson {
     }
 
     public static void writeRequirements(OutputStream out, FabricRequirements value) throws IOException {
+    	//ENTESB-5041 : fabric:requirements-export" command to indent requirements-export json output
+    	mapper.enable(SerializationFeature.INDENT_OUTPUT);
         mapper.writeValue(out, value);
     }
 


### PR DESCRIPTION
Added option to indent and to reset to no indent by default
for indenting the output
requirements-export --indent true <filepath> 
for regular output
requirements-export --indent true <filepath> 
default with no indentation
requirements-export  <filepath> 
