### PR TITLE
[ENTESB-4992] patch:add checks if the file:// represents existing file

### DIFF
--- a/patch/patch-core/src/main/java/io/fabric8/patch/impl/ServiceImpl.java
+++ b/patch/patch-core/src/main/java/io/fabric8/patch/impl/ServiceImpl.java
@@ -20,6 +20,7 @@ import java.io.FileFilter;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -291,6 +292,16 @@ public class ServiceImpl implements Service {
 
     @Override
     public Iterable<Patch> download(URL url) {
+        if ("file".equals(url.getProtocol())) {
+            // ENTESB-4992: prevent adding non existing files or directories
+            try {
+                if (!new File(url.toURI()).isFile()) {
+                    throw new PatchException("Path " + url.getPath() + " doesn't exist or is not a file");
+                }
+            } catch (URISyntaxException e) {
+                throw new PatchException(e.getMessage(), e);
+            }
+        }
         try {
             List<PatchData> patchesData = patchManagement.fetchPatches(url);
             List<Patch> patches = new ArrayList<>(patchesData.size());

--- a/patch/patch-core/src/test/java/io/fabric8/patch/impl/ServiceImplTest.java
+++ b/patch/patch-core/src/test/java/io/fabric8/patch/impl/ServiceImplTest.java
@@ -728,7 +728,7 @@ public class ServiceImplTest {
 
     private Bundle createMockBundle(String bsn, String version, String location) {
         Bundle result = createNiceMock(Bundle.class);
-        expect(result.getSymbolicName()).andReturn(bsn);
+        expect(result.getSymbolicName()).andReturn(bsn).anyTimes();
         expect(result.getVersion()).andReturn(Version.parseVersion(version));
         expect(result.getLocation()).andReturn(location);
         replay(result);


### PR DESCRIPTION
(cherry picked from commit c856a782f3f854351fc3ac853c431b935c628a8b)
