### PR TITLE
[ENTESB-4388] Add container-restart command

### DIFF
--- a/fabric/fabric-commands/src/main/java/io/fabric8/commands/ContainerRestart.java
+++ b/fabric/fabric-commands/src/main/java/io/fabric8/commands/ContainerRestart.java
@@ -1,0 +1,75 @@
+package io.fabric8.commands;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.felix.gogo.commands.Action;
+import org.apache.felix.gogo.commands.basic.AbstractCommand;
+import org.apache.felix.scr.annotations.Activate;
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Deactivate;
+import org.apache.felix.scr.annotations.Property;
+import org.apache.felix.scr.annotations.Reference;
+import org.apache.felix.scr.annotations.Service;
+import org.apache.felix.service.command.Function;
+
+import io.fabric8.api.FabricService;
+import io.fabric8.api.scr.ValidatingReference;
+import io.fabric8.boot.commands.support.AbstractCommandComponent;
+import io.fabric8.boot.commands.support.ContainerCompleter;
+import io.fabric8.commands.support.StartedContainerCompleter;
+import io.fabric8.zookeeper.curator.CuratorFrameworkLocator;
+
+/**
+ * Container restart command component class.
+ * Created by avano on 24.3.16.
+ */
+@Component(immediate = true)
+@Service({ Function.class, AbstractCommand.class })
+@org.apache.felix.scr.annotations.Properties({
+		@Property(name = "osgi.command.scope", value = ContainerRestart.SCOPE_VALUE),
+		@Property(name = "osgi.command.function", value = ContainerRestart.FUNCTION_VALUE)
+})
+public class ContainerRestart extends AbstractCommandComponent {
+	public static final String SCOPE_VALUE = "fabric";
+	public static final String FUNCTION_VALUE = "container-restart";
+	public static final String DESCRIPTION = "Restart specified containers";
+
+	@Reference(referenceInterface = FabricService.class)
+	private final ValidatingReference<FabricService> fabricService = new ValidatingReference<>();
+
+	// Completers
+	@Reference(referenceInterface = ContainerCompleter.class, bind = "bindContainerCompleter", unbind = "unbindContainerCompleter")
+	private ContainerCompleter containerCompleter; // dummy field
+
+	@Activate
+	void activate() {
+		activateComponent();
+	}
+
+	@Deactivate
+	void deactivate() {
+		deactivateComponent();
+	}
+
+	@Override
+	public Action createNewAction() {
+		assertValid();
+		CuratorFramework curator = CuratorFrameworkLocator.getCuratorFramework();
+		return new ContainerRestartAction(fabricService.get(), curator);
+	}
+
+	void bindFabricService(FabricService fabricService) {
+		this.fabricService.bind(fabricService);
+	}
+
+	void unbindFabricService(FabricService fabricService) {
+		this.fabricService.unbind(fabricService);
+	}
+
+	void bindContainerCompleter(ContainerCompleter completer) {
+		bindCompleter(completer);
+	}
+
+	void unbindContainerCompleter(ContainerCompleter completer) {
+		unbindCompleter(completer);
+	}
+}

--- a/fabric/fabric-commands/src/main/java/io/fabric8/commands/ContainerRestartAction.java
+++ b/fabric/fabric-commands/src/main/java/io/fabric8/commands/ContainerRestartAction.java
@@ -1,0 +1,158 @@
+package io.fabric8.commands;
+
+import static io.fabric8.utils.FabricValidations.validateContainerName;
+import static io.fabric8.zookeeper.utils.ZooKeeperUtils.exists;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.felix.gogo.commands.Command;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import io.fabric8.api.Container;
+import io.fabric8.api.ContainerProvider;
+import io.fabric8.api.CreateContainerMetadata;
+import io.fabric8.api.FabricService;
+
+/**
+ * Class for the container-restart action.
+ * Created by avano on 24.3.16.
+ */
+
+@Command(name = ContainerRestart.FUNCTION_VALUE, scope = ContainerRestart.SCOPE_VALUE, description = ContainerRestart.DESCRIPTION,
+		detailedDescription = "classpath:containerRestart.txt")
+public class ContainerRestartAction extends AbstractContainerLifecycleAction {
+	private static final Logger LOGGER = LoggerFactory.getLogger(ContainerRestartAction.class);
+	private static final long TIMEOUT = 120000L;
+	private CuratorFramework curator;
+	private boolean restartCurrentContainer = false;
+	private List<Container> restartedContainers = new ArrayList<>();
+
+	public ContainerRestartAction(FabricService fabricService, CuratorFramework curator) {
+		super(fabricService);
+		this.curator = curator;
+	}
+
+	@Override
+	protected Object doExecute() throws Exception {
+		List<Container> containerList = getEligibleContainers(super.expandGlobNames(containers));
+
+		// First execute stop on all containers
+		for (Container c : containerList) {
+			try {
+				fabricService.stopContainer(c, force);
+				restartedContainers.add(c);
+			} catch (UnsupportedOperationException uoe) {
+				// Usecase for managed containers that are not created using Fabric - joined containers for example
+				if (uoe.getMessage().contains("has not been created using Fabric")) {
+					LOGGER.warn("Container " + c.getId() + " has not been created using Fabric, skipping restart.");
+				} else {
+					throw uoe;
+				}
+			}
+		}
+
+		// Wait for all containers to stop
+		for (Container c : restartedContainers) {
+			long startedAt = System.currentTimeMillis();
+			// Wait until the zk node /fabric/registry/containers/status/<container name>/pid disappears
+			// Or until the time is up
+			// Let this cycle pass atleast 1 time to make it more reliable
+			do {
+				try {
+					Thread.sleep(3000);
+				} catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+					return null;
+				}
+			} while (!Thread.interrupted() && startedAt + TIMEOUT > System.currentTimeMillis() &&
+					exists(curator, "/fabric/registry/containers/status/" + c.getId() + "/pid") != null);
+		}
+
+		// Start the containers back
+		for (Container c : restartedContainers) {
+			c.start(force);
+		}
+
+		printRestartedContainers(restartedContainers);
+
+		if (restartCurrentContainer) {
+			System.setProperty("karaf.restart.jvm", "true");
+			System.out.println("Restart flag for container \'" + fabricService.getCurrentContainerName() + "\' set,"
+					+ " please stop the container manually.");
+		}
+
+		return null;
+	}
+
+	/**
+	 * Prints the restarted containers list.
+	 * @param containerList restarted containers list
+	 */
+	private void printRestartedContainers(List<Container> containerList) {
+		if (containerList.size() == 0) {
+			return;
+		}
+
+		StringBuilder containers = new StringBuilder("The list of restarted containers: [");
+		for (Container c : containerList) {
+			containers.append(c.getId());
+			containers.append(", ");
+		}
+		containers.setLength(containers.length() - 2);
+		containers.append("]");
+		System.out.println(containers.toString());
+	}
+
+	/**
+	 * Pick the containers eligible for restart from the collection of container names.
+	 * @param names container names
+	 * @return list of containers eligible for restart
+	 */
+	private List<Container> getEligibleContainers(Collection<String> names) {
+		List<Container> containerList = new ArrayList<>();
+		for (String containerName : names) {
+			validateContainerName(containerName);
+			if (containerName.equals(fabricService.getCurrentContainerName())) {
+				if (fabricService.getCurrentContainer().isRoot() && !isSshContainer(fabricService.getCurrentContainer())) {
+					restartCurrentContainer = true;
+				} else {
+					LOGGER.warn("Container " + containerName + " can't be restarted from itself");
+				}
+				continue;
+			}
+			if (!fabricService.getContainer(containerName).isManaged()) {
+				LOGGER.warn("Container " + containerName + " is not managed by Fabric, skipping restart.");
+				continue;
+			}
+			containerList.add(fabricService.getContainer(containerName));
+		}
+		return containerList;
+	}
+
+	/**
+	 * Checks if the container is an SSH container.
+	 * @param container container
+	 * @return true/false
+	 */
+	private boolean isSshContainer(Container container) {
+		CreateContainerMetadata metadata = container.getMetadata();
+		String type = metadata != null ? metadata.getCreateOptions().getProviderType() : null;
+
+		if (type == null) {
+			return false;
+		}
+
+		ContainerProvider provider = fabricService.getProvider(type);
+
+		if (provider == null) {
+			return false;
+		}
+
+		return provider == null ? false : "ssh".equals(provider.getScheme());
+	}
+}

--- a/fabric/fabric-commands/src/main/resources/io/fabric8/commands/containerRestart.txt
+++ b/fabric/fabric-commands/src/main/resources/io/fabric8/commands/containerRestart.txt
@@ -1,0 +1,9 @@
+Container restart executes three phases:
+
+* Execute stop command on every container
+
+* Wait until the containers are stopped (waits up to 2 minutes for each restarted container)
+
+* Execute start command on every container
+
+If the current container should and can be restarted, the appropriate flag will be set and you need to shut down the container manually.


### PR DESCRIPTION
Added container-restart command.

It gets list of container names, filter out non-applicable (not managed by fabric) and tries to restart.

Then it waits for the zk node /fabric/registry/containers/status/<container name>/pid to disappear - to be sure the container is stopped.

If the current container where we execute the command should be restarted, check if we can do a (half-)restart - if it is a root container and it is not an ssh container, then we can set the system property and tell the user that he should stop the container manually.

@paoloantinori could you review this please?

I'd extract the is-SSH-container checking into the container itself, but that required a bigger modification in all implementations
