### PR TITLE
ENTESB-5243 - ENTESB-4265 - Upgrade pax-url to 2.4.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -312,7 +312,7 @@
         <pax.logging.version>1.8.4</pax.logging.version>
         <pax.url.mvn.commons.version>${pax.url.version}</pax.url.mvn.commons.version>
         <pax.url.mvn.version>${pax.url.version}</pax.url.mvn.version>
-        <pax.url.version>2.4.2</pax.url.version>
+        <pax.url.version>2.4.7</pax.url.version>
         <pax.web.version>3.2.0</pax.web.version>
         <plexus-utils-version>3.0.17</plexus-utils-version>
         <plexus-classworlds-version>2.4</plexus-classworlds-version>


### PR DESCRIPTION
Fixes the behavior of Maven proxies that allows to pickup updated released artifacts
