### PR TITLE
ENTESB-5254 - Container-create-ssh does not respect --new-user and --new-user-password

### DIFF
--- a/fabric/fabric-core-agent-jclouds/src/main/java/io/fabric8/service/jclouds/commands/ContainerCreateCloud.java
+++ b/fabric/fabric-core-agent-jclouds/src/main/java/io/fabric8/service/jclouds/commands/ContainerCreateCloud.java
@@ -95,11 +95,11 @@ public class ContainerCreateCloud extends AbstractContainerCreateAction {
     @Option(name = "--max-port", multiValued = false, description = "The maximum port of the allowed port range")
     private int maximumPort = Ports.MAX_PORT_NUMBER;
 
-    @Option(name = "--new-user", multiValued = false, description = "The username of a new user. The option refers to karaf user (ssh, http, jmx).")
+    @Option(name = "--new-user", multiValued = false, description = "The username of a new user. The option refers to karaf user (ssh, http, jmx). It takes effect only when used in combination with the --ensemble-server option.")
     private String newUser="admin";
-    @Option(name = "--new-user-password", multiValued = false, description = "The password of the new user. The option refers to karaf user (ssh, http, jmx).")
+    @Option(name = "--new-user-password", multiValued = false, description = "The password of the new user. The option refers to karaf user (ssh, http, jmx). It takes effect only when used in combination with the --new-user and --ensemble-server options.")
     private String newUserPassword;
-    @Option(name = "--new-user-role", multiValued = false, description = "The role of the new user. The option refers to karaf user (ssh, http, jmx).")
+    @Option(name = "--new-user-role", multiValued = false, description = "The role of the new user. The option refers to karaf user (ssh, http, jmx). It takes effect only when used in combination with the --new-user and --ensemble-server options.")
     private String newUserRole = "admin";
     @Option(name = "--disable-distribution-upload", multiValued = false, description = "Flag to disable uploading the distribution. When used distribution will be downloaded via maven")
     private Boolean distributionUploadDisable = false;

--- a/fabric/fabric-core-agent-ssh/src/main/java/io/fabric8/service/ssh/commands/ContainerCreateSshAction.java
+++ b/fabric/fabric-core-agent-ssh/src/main/java/io/fabric8/service/ssh/commands/ContainerCreateSshAction.java
@@ -61,11 +61,11 @@ public class ContainerCreateSshAction extends AbstractContainerCreateAction {
     @Option(name = "--pass-phrase", description = "The pass phrase of the key. This is for use with private keys that require a pass phrase.")
     private String passPhrase;
 
-    @Option(name = "--new-user", multiValued = false, description = "The username of a new user. The option refers to karaf user (ssh, http, jmx).")
+    @Option(name = "--new-user", multiValued = false, description = "The username of a new user. The option refers to karaf user (ssh, http, jmx). It takes effect only when used in combination with the --ensemble-server option.")
     private String newUser="admin";
-    @Option(name = "--new-user-password", multiValued = false, description = "The password of the new user. The option refers to karaf user (ssh, http, jmx).")
+    @Option(name = "--new-user-password", multiValued = false, description = "The password of the new user. The option refers to karaf user (ssh, http, jmx). It takes effect only when used in combination with the --new-user and --ensemble-server options.")
     private String newUserPassword;
-    @Option(name = "--new-user-role", multiValued = false, description = "The role of the new user. The option refers to karaf user (ssh, http, jmx).")
+    @Option(name = "--new-user-role", multiValued = false, description = "The role of the new user. The option refers to karaf user (ssh, http, jmx). It takes effect only when used in combination with the --new-user and --ensemble-server options.")
     private String newUserRole = "admin";
     @Option(name = "--with-admin-access", description = "Indicates that the target user has admin access (password-less sudo). When used installation of missing dependencies will be attempted.")
     private boolean adminAccess;


### PR DESCRIPTION
https://issues.jboss.org/browse/ENTESB-5254

Just enhance the help descriptions for the --new-user(-xxx) options.
