### PR TITLE
[ENTESB-5517] Handle ZIP's root directory for R patch correctly, allo…

### DIFF
--- a/patch/patch-management/src/main/java/io/fabric8/patch/management/impl/GitPatchManagementServiceImpl.java
+++ b/patch/patch-management/src/main/java/io/fabric8/patch/management/impl/GitPatchManagementServiceImpl.java
@@ -396,7 +396,8 @@ public class GitPatchManagementServiceImpl implements PatchManagement, GitPatchM
                     boolean skipRootDir = false;
                     for (Enumeration<ZipArchiveEntry> e = zf.getEntries(); e.hasMoreElements(); ) {
                         ZipArchiveEntry entry = e.nextElement();
-                        if (!skipRootDir && (entry.getName().startsWith("jboss-fuse-")
+                        if (!skipRootDir && entry.isDirectory()
+                                && (entry.getName().startsWith("jboss-fuse-")
                                 || entry.getName().startsWith("jboss-a-mq-"))) {
                             skipRootDir = true;
                         }


### PR DESCRIPTION
…w jboss-fuse- and jboss-a-mq- prefixed patch descriptors

(cherry picked from commit 672eaf442690e1117ce16978d14dabd2dda01822)
