### PR TITLE
[ENTESB-5095] Introducing the fabric protocol that handles complex bu…

### DIFF
--- a/fabric/fabric-agent/src/test/java/io/fabric8/agent/region/SubsystemTest.java
+++ b/fabric/fabric-agent/src/test/java/io/fabric8/agent/region/SubsystemTest.java
@@ -1,0 +1,32 @@
+package io.fabric8.agent.region;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+public class SubsystemTest {
+    @Test
+    public void requireFabricBundle() throws Exception {
+        //given
+        Subsystem subsystem = new Subsystem("ENTESB-5095");
+        final String dependency = "true";
+        final String startLevel = "50";
+        final String start = "false";
+        String requirement = "fabric:wrap:mvn:org.apache.poi/ooxml-security/1.0$Export-Package=org.etsi.uri.x01903.v14;version=1.0;;start=" + start + ";start-level=" + startLevel + ";dependency=" + dependency;
+        assertTrue("Requirement is a fabric bundle!",Subsystem.FabricBundle.isFabricBundle(requirement));
+        
+        //when
+        subsystem.require("bundle:"+requirement);
+        
+        //then
+        List<Subsystem.FabricBundle> fabricBundles = subsystem.getFabricBundles();
+        assertEquals(1,fabricBundles.size());
+        Subsystem.FabricBundle fabricBundle = fabricBundles.get(0);
+        assertEquals("wrap:mvn:org.apache.poi/ooxml-security/1.0$Export-Package=org.etsi.uri.x01903.v14;version=1.0",fabricBundle.getLocation());
+        assertEquals(start,fabricBundle.getProperty("start"));
+        assertEquals(startLevel,fabricBundle.getProperty("start-level"));
+        assertEquals(dependency,fabricBundle.getProperty("dependency"));
+    }
+}


### PR DESCRIPTION
…ndle URIs in fabric profiles

This solves https://issues.jboss.org/browse/ENTESB-5095. Essentially we'll be able to add complex bundle URIs to fabric profiles be it through the fabric8:maven:plugin or through the fabric:profile-edit command e.g:

fabric:profile-edit --bundle _fabric_:webbundle:http://tomcat.apache.org/tomcat-7.0-doc/appdev/sample/sample.war?Bundle-SymbolicName=tomcat-sample&Web-ContextPath=/sample;;start-level=50 profile

I've opted to introduce a new protocol called _fabric_ as to not break backward compatibility (which should make things like patching easier). The protocol syntax is as follows:

fabric:[standard-bundle-URI][;;OPTIONS]

where:
- [standard-bundle-URI] is any standard supported bundle URI ([examples](https://ops4j1.jira.com/wiki/display/paxurl/User+Guide))
- ";;" is the delimiter used in the URI to indicate the end of the [standard-bundle-URI] and the start of fabric options.
- OPTIONS are the same fabric options available through the standard bundle protocol [(start-level, start and dependency)](https://github.com/jboss-fuse/fabric8/blob/1.2.0.redhat-6-3-x/fabric/fabric-agent/src/main/java/io/fabric8/agent/region/Subsystem.java#L390-L394). The above URI uses the start-level option as an example.

@grgrzybek @paoloantinori what do you think ?
