### PR TITLE
ENTESB-5775,ENTESB-5219 - Make RBACRestrictor always use canInvoke(String, String, String[])

### DIFF
--- a/fabric/fabric-jolokia/src/main/java/io/fabric8/jolokia/RBACRestrictor.java
+++ b/fabric/fabric-jolokia/src/main/java/io/fabric8/jolokia/RBACRestrictor.java
@@ -138,15 +138,8 @@ public class RBACRestrictor implements Restrictor {
         }
         List<String> argTypes = new ArrayList<>();
         String opName = parseOperation(operation, argTypes);
-        Object[] params;
-        String[] signature;
-        if (argTypes.isEmpty()) {
-            params = new Object[] { objectName.getCanonicalName(), opName };
-            signature = new String[] { String.class.getName(), String.class.getName() };
-        } else {
-            params = new Object[] { objectName.getCanonicalName(), opName, argTypes.toArray(new String[0]) };
-            signature = new String[] { String.class.getName(), String.class.getName(), String[].class.getName() };
-        }
+        Object[] params = new Object[] { objectName.getCanonicalName(), opName, argTypes.toArray(new String[0]) };
+        String[] signature = new String[] { String.class.getName(), String.class.getName(), String[].class.getName() };
         try {
             return (boolean) mBeanServer.invoke(securityMBean, "canInvoke", params, signature);
         } catch (InstanceNotFoundException e) {

--- a/fabric/fabric-jolokia/src/test/java/io/fabric8/jolokia/RBACRestrictorTest.java
+++ b/fabric/fabric-jolokia/src/test/java/io/fabric8/jolokia/RBACRestrictorTest.java
@@ -65,7 +65,7 @@ public class RBACRestrictorTest {
         assertThat(restrictor.isOperationAllowed(new ObjectName("fabric:type=Test"), "allowed()"), is(true));
         assertThat(restrictor.isOperationAllowed(new ObjectName("fabric:type=Test"), "notAllowed()"), is(false));
         assertThat(restrictor.isOperationAllowed(new ObjectName("fabric:type=Test"), "error()"), is(false));
-        assertThat(restrictor.isOperationAllowed(new ObjectName("hawtio:type=NoSuchType"), "noInstance()"), is(false));
+        assertThat(restrictor.isOperationAllowed(new ObjectName("fabric:type=NoSuchType"), "noInstance()"), is(false));
 
         assertThat(restrictor.isOperationAllowed(new ObjectName("fabric:type=Test"), "allowed(boolean,long,java.lang.String)"), is(true));
         assertThat(restrictor.isOperationAllowed(new ObjectName("fabric:type=Test"), "notAllowed(boolean,long,java.lang.String)"), is(false));
@@ -96,35 +96,37 @@ public class RBACRestrictorTest {
     private class JMXSecurity implements JMXSecurityMBean {
         @Override
         public boolean canInvoke(String objectName, String methodName) throws Exception {
-            LOG.debug("{}, {}", objectName, methodName);
-            if ("fabric:type=Test".equals(objectName) && "allowed".equals(methodName)) {
-                return true;
-            }
-            if ("fabric:type=Test".equals(objectName) && "error".equals(methodName)) {
-                throw new Exception();
-            }
-            if ("hawtio:type=NoSuchType".equals(objectName) && "noInstance".equals(methodName)) {
-                throw new InstanceNotFoundException(objectName);
-            }
-            if ("java.lang:type=Runtime".equals(objectName) && "getVmName".equals(methodName)) {
-                return true;
-            }
-            if ("java.lang:type=Memory".equals(objectName) && "isVerbose".equals(methodName)) {
-                return true;
-            }
             return false;
         }
 
         @Override
         public boolean canInvoke(String objectName, String methodName, String[] argTypes) throws Exception {
             LOG.debug("{}, {}, {}", objectName, methodName, Arrays.asList(argTypes));
-            if ("fabric:type=Test".equals(objectName) && "allowed".equals(methodName) && argTypes.length == 3
-                    && "boolean".equals(argTypes[0]) && "long".equals(argTypes[1]) && "java.lang.String".equals(argTypes[2])) {
-                return true;
-            }
-            if ("java.lang:type=Memory".equals(objectName) && "setVerbose".equals(methodName) && argTypes.length == 1
-                    && "boolean".equals(argTypes[0])) {
-                return true;
+            if (argTypes.length == 0) {
+                if ("fabric:type=Test".equals(objectName) && "allowed".equals(methodName)) {
+                    return true;
+                }
+                if ("fabric:type=Test".equals(objectName) && "error".equals(methodName)) {
+                    throw new Exception();
+                }
+                if ("fabric:type=NoSuchType".equals(objectName) && "noInstance".equals(methodName)) {
+                    throw new InstanceNotFoundException(objectName);
+                }
+                if ("java.lang:type=Runtime".equals(objectName) && "getVmName".equals(methodName)) {
+                    return true;
+                }
+                if ("java.lang:type=Memory".equals(objectName) && "isVerbose".equals(methodName)) {
+                    return true;
+                }
+            } else {
+                if ("fabric:type=Test".equals(objectName) && "allowed".equals(methodName) && argTypes.length == 3
+                        && "boolean".equals(argTypes[0]) && "long".equals(argTypes[1]) && "java.lang.String".equals(argTypes[2])) {
+                    return true;
+                }
+                if ("java.lang:type=Memory".equals(objectName) && "setVerbose".equals(methodName) && argTypes.length == 1
+                        && "boolean".equals(argTypes[0])) {
+                    return true;
+                }
             }
             return false;
         }


### PR DESCRIPTION
https://issues.jboss.org/browse/ENTESB-5775
