### PR TITLE
ENTESB-5904 - Moved jmx.acl.whitelist.properties from default profile…

### DIFF
--- a/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/acls.profile/jmx.acl.whitelist.properties
+++ b/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/acls.profile/jmx.acl.whitelist.properties
@@ -1,3 +1,19 @@
+#
+#  Copyright 2005-2016 Red Hat, Inc.
+#
+#  Red Hat licenses this file to you under the Apache License, version
+#  2.0 (the "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied.  See the License for the specific language governing
+#  permissions and limitations under the License.
+#
+
 # open this up so we can check available plugins before authenticating
 hawtio.plugin=bypass
 # open this up so that permissions can validated by anyone


### PR DESCRIPTION
… in Fuse repo to acls profile in Fabric8 repo
