### PR TITLE
PATCH-1981 - Issue with Vertx and jdk 1.7

### DIFF
--- a/gateway/gateway-core/src/test/java/io/fabric8/gateway/handlers/detecting/DetectingGatewayTest.java
+++ b/gateway/gateway-core/src/test/java/io/fabric8/gateway/handlers/detecting/DetectingGatewayTest.java
@@ -74,17 +74,24 @@ public class DetectingGatewayTest {
 
     // Setup Vertx
     protected Vertx vertx;
+    // used to swap threads since Vertx.stop() does funky stuff.
+    // see https://github.com/vert-x/mod-lang-clojure/commit/fa6f78874a0c3507955dc5743f833cfbbbb60cb5
+    Thread current = null;
+
     @Before
     public void startVertx() {
+        current = Thread.currentThread();
         if( vertx == null ) {
             vertx = VertxFactory.newVertx();
         }
     }
     @After
     public void stopVertx(){
+        ClassLoader tccl = current.getContextClassLoader();
         if( vertx!=null ) {
             vertx.stop();
             vertx = null;
+            current.setContextClassLoader(tccl);
         }
     }
 

--- a/gateway/gateway-core/src/test/java/io/fabric8/gateway/handlers/detecting/DetectingGatewayVirtualHostTest.java
+++ b/gateway/gateway-core/src/test/java/io/fabric8/gateway/handlers/detecting/DetectingGatewayVirtualHostTest.java
@@ -72,17 +72,23 @@ public class DetectingGatewayVirtualHostTest {
 
     // Setup Vertx
     protected Vertx vertx;
+    // used to swap threads since Vertx.stop() does funky stuff.
+    // see https://github.com/vert-x/mod-lang-clojure/commit/fa6f78874a0c3507955dc5743f833cfbbbb60cb5
+    Thread current = null;
     @Before
     public void startVertx() {
+        current = Thread.currentThread();
         if( vertx == null ) {
             vertx = VertxFactory.newVertx();
         }
     }
     @After
     public void stopVertx(){
+        ClassLoader tccl = current.getContextClassLoader();
         if( vertx!=null ) {
             vertx.stop();
             vertx = null;
+            current.setContextClassLoader(tccl);
         }
     }
 


### PR DESCRIPTION
This fix is required to have unit test running fine under jdk 1.7.
See: https://github.com/vert-x/mod-lang-clojure/commit/fa6f78874a0c3507955dc5743f833cfbbbb60cb5