### PR TITLE
[PATCH-1810] ENTESB-6660 - CXF endpoints not getting registered in Fabric registry / not exposed by HTTP Gateway

### DIFF
--- a/fabric/fabric8-karaf/src/main/resources/fabric-features.xml
+++ b/fabric/fabric8-karaf/src/main/resources/fabric-features.xml
@@ -320,12 +320,12 @@
         <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-databind/${jackson2-version}</bundle>
         <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2-version}</bundle>
         <bundle dependency='true'>mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/${jackson2-version}</bundle>
-        <bundle>mvn:io.fabric8/fabric-cxf/${project.version}</bundle>
+        <bundle start-level="60">mvn:io.fabric8/fabric-cxf/${project.version}</bundle>
     </feature>
 
     <feature name="fabric-cxf-registry" version="${project.version}" resolver="(obr)">
         <feature>fabric-core</feature>
-        <bundle>mvn:io.fabric8/fabric-cxf-registry/${project.version}</bundle>
+        <bundle start-level="59">mvn:io.fabric8/fabric-cxf-registry/${project.version}</bundle>
         <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-core/${jackson2-version}</bundle>
         <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-databind/${jackson2-version}</bundle>
         <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2-version}</bundle>


### PR DESCRIPTION
https://issues.jboss.org/browse/ENTESB-6660
https://issues.jboss.org/browse/PATCH-1810

Set start-level for fabric-cxf-registry / fabric-cxf to 59 / 60 so they won't start at 'hot' standby but start before user bundles (>= 80)