### PR TITLE
Artifacts are not uploaded to the repository if fabric8.includeArtifact is set to false. 

### DIFF
--- a/fabric8-maven-plugin/src/main/java/io/fabric8/maven/DeployToProfileMojo.java
+++ b/fabric8-maven-plugin/src/main/java/io/fabric8/maven/DeployToProfileMojo.java
@@ -259,7 +259,7 @@ public class DeployToProfileMojo extends AbstractProfileMojo {
             // now lets invoke the mbean
             J4pClient client = createJolokiaClient();
 
-            if (upload && isIncludeArtifact()) {
+            if (upload) {
                 uploadDeploymentUnit(client, newUserAdded || customUsernameAndPassword);
             } else {
                 getLog().info("Uploading to the fabric8 maven repository is disabled");


### PR DESCRIPTION
Most of the time there is a need when we just want to add a feature to a profile and thus we can avoid adding bunch of artifacts as a bundle dependency in a profile.
To facilitate this, there is a fabric8.includeArtifact parameter. It accepts boolean true and false. So when set to false, a profile is created without bundles in dependency section.
But the disadvantage is that if it is set to false than fabric8 maven plugin doesn't upload artifacts to the repository.
https://issues.jboss.org/browse/ENTESB-7119