### PR TITLE
ENTESB-7259 - fix for duplicated broker

### DIFF
--- a/mq/mq-fabric/src/main/java/io/fabric8/mq/fabric/BrokerDeployment.java
+++ b/mq/mq-fabric/src/main/java/io/fabric8/mq/fabric/BrokerDeployment.java
@@ -66,7 +66,6 @@ public class BrokerDeployment {
         properties.remove("component.id");
         properties.remove("component.name");
         properties.remove("service.factoryPid");
-        properties.remove("fabric.zookeeper.pid");
         String pid = (String) properties.remove("service.pid");
         properties.put("mq.fabric.server.pid", pid);
         properties.put("mq.fabric.server.ts", LOAD_TS);


### PR DESCRIPTION
This has a corresponding commit in `fuse` project, to alter the `etc/io.fabric8.mq.fabric.server-broker.cfg` file.