### PR TITLE
ENTESB-7329: EncryptionOperationNotPossibleException when calling io.fabric8:type=Fabric/containers() from all fabric containers when wrong encryption key is used.

### DIFF
--- a/fabric/fabric-core/src/main/java/io/fabric8/service/FabricServiceImpl.java
+++ b/fabric/fabric-core/src/main/java/io/fabric8/service/FabricServiceImpl.java
@@ -93,6 +93,7 @@ import org.apache.felix.scr.annotations.Deactivate;
 import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.ReferencePolicy;
 import org.apache.felix.scr.annotations.Service;
+import org.jasypt.exceptions.EncryptionOperationNotPossibleException;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
@@ -1326,19 +1327,21 @@ public final class FabricServiceImpl extends AbstractComponent implements Fabric
             for (Map.Entry<String, String> e : original.entrySet()) {
                 final String key = e.getKey();
                 final String value = e.getValue();
-                try{
-                props.put(key, InterpolationHelper.substVars(value, key, null, props, new InterpolationHelper.SubstitutionCallback() {
-                    public String getValue(String toSubstitute) {
-                        if (toSubstitute != null && toSubstitute.contains(":")) {
-                            String scheme = toSubstitute.substring(0, toSubstitute.indexOf(":"));
-                            return resolversSnapshot.get(scheme).resolve(fabricService, mutableConfigurations, pid, key, toSubstitute);
-                        }
-                        return substituteBundleProperty(toSubstitute, bundleContext);
-                    }
-                }));
-                }catch(Exception exception){
-                	LOGGER.warn("Error resolving "+ key, exception);
-                }
+				try {
+					props.put(key, InterpolationHelper.substVars(value, key, null, props,
+							new InterpolationHelper.SubstitutionCallback() {
+								public String getValue(String toSubstitute) {
+									if (toSubstitute != null && toSubstitute.contains(":")) {
+										String scheme = toSubstitute.substring(0, toSubstitute.indexOf(":"));
+										return resolversSnapshot.get(scheme).resolve(fabricService,
+												mutableConfigurations, pid, key, toSubstitute);
+									}
+									return substituteBundleProperty(toSubstitute, bundleContext);
+								}
+							}));
+				} catch (Exception exception) {
+					LOGGER.warn("Error resolving " + key, exception);
+				}
             }
         }
         

--- a/fabric/fabric-core/src/main/java/io/fabric8/service/FabricServiceImpl.java
+++ b/fabric/fabric-core/src/main/java/io/fabric8/service/FabricServiceImpl.java
@@ -1328,17 +1328,15 @@ public final class FabricServiceImpl extends AbstractComponent implements Fabric
                 final String key = e.getKey();
                 final String value = e.getValue();
 				try {
-					props.put(key, InterpolationHelper.substVars(value, key, null, props,
-							new InterpolationHelper.SubstitutionCallback() {
-								public String getValue(String toSubstitute) {
-									if (toSubstitute != null && toSubstitute.contains(":")) {
-										String scheme = toSubstitute.substring(0, toSubstitute.indexOf(":"));
-										return resolversSnapshot.get(scheme).resolve(fabricService,
-												mutableConfigurations, pid, key, toSubstitute);
-									}
-									return substituteBundleProperty(toSubstitute, bundleContext);
-								}
-							}));
+					props.put(key, InterpolationHelper.substVars(value, key, null, props, new InterpolationHelper.SubstitutionCallback() {
+                    public String getValue(String toSubstitute) {
+                        if (toSubstitute != null && toSubstitute.contains(":")) {
+                            String scheme = toSubstitute.substring(0, toSubstitute.indexOf(":"));
+                            return resolversSnapshot.get(scheme).resolve(fabricService, mutableConfigurations, pid, key, toSubstitute);
+                        }
+                        return substituteBundleProperty(toSubstitute, bundleContext);
+                    }
+                }));
 				} catch (Exception exception) {
 					LOGGER.warn("Error resolving " + key, exception);
 				}

--- a/fabric/fabric-core/src/main/java/io/fabric8/service/FabricServiceImpl.java
+++ b/fabric/fabric-core/src/main/java/io/fabric8/service/FabricServiceImpl.java
@@ -1326,6 +1326,7 @@ public final class FabricServiceImpl extends AbstractComponent implements Fabric
             for (Map.Entry<String, String> e : original.entrySet()) {
                 final String key = e.getKey();
                 final String value = e.getValue();
+                try{
                 props.put(key, InterpolationHelper.substVars(value, key, null, props, new InterpolationHelper.SubstitutionCallback() {
                     public String getValue(String toSubstitute) {
                         if (toSubstitute != null && toSubstitute.contains(":")) {
@@ -1335,6 +1336,9 @@ public final class FabricServiceImpl extends AbstractComponent implements Fabric
                         return substituteBundleProperty(toSubstitute, bundleContext);
                     }
                 }));
+                }catch(Exception exception){
+                	LOGGER.warn("Error resolving "+ key, exception);
+                }
             }
         }
         


### PR DESCRIPTION
ENTESB-7329: This fix just properly catch the exception and properly log it without printing stacktrace in output of mbean 'io.fabric8:type=Fabric/containers()'.