### PR TITLE
ENTESB-7329: EncryptionOperationNotPossibleException when calling 'io.fabric8:type=Fabric/containers()' from all fabric containers when wrong encryption key is used.

### DIFF
--- a/fabric/fabric-core/src/main/java/io/fabric8/service/FabricServiceImpl.java
+++ b/fabric/fabric-core/src/main/java/io/fabric8/service/FabricServiceImpl.java
@@ -1387,6 +1387,7 @@ public final class FabricServiceImpl extends AbstractComponent implements Fabric
             for (Map.Entry<String, String> e : original.entrySet()) {
                 final String key = e.getKey();
                 final String value = e.getValue();
+                try {
                 props.put(key, InterpolationHelper.substVars(value, key, null, props, new InterpolationHelper.SubstitutionCallback() {
                     public String getValue(String toSubstitute) {
                         if (toSubstitute != null && toSubstitute.contains(":")) {
@@ -1396,6 +1397,9 @@ public final class FabricServiceImpl extends AbstractComponent implements Fabric
                         return substituteBundleProperty(toSubstitute, bundleContext);
                     }
                 }));
+                } catch(EncryptionOperationNotPossibleException exception) {
+                    LOGGER.warn("Error resolving " + key, exception);
+                }
             }
         }
         

--- a/fabric/fabric-core/src/main/java/io/fabric8/service/FabricServiceImpl.java
+++ b/fabric/fabric-core/src/main/java/io/fabric8/service/FabricServiceImpl.java
@@ -1389,16 +1389,16 @@ public final class FabricServiceImpl extends AbstractComponent implements Fabric
                 final String key = e.getKey();
                 final String value = e.getValue();
                 try {
-                props.put(key, InterpolationHelper.substVars(value, key, null, props, new InterpolationHelper.SubstitutionCallback() {
-                    public String getValue(String toSubstitute) {
-                        if (toSubstitute != null && toSubstitute.contains(":")) {
-                            String scheme = toSubstitute.substring(0, toSubstitute.indexOf(":"));
-                            return resolversSnapshot.get(scheme).resolve(fabricService, mutableConfigurations, pid, key, toSubstitute);
+                    props.put(key, InterpolationHelper.substVars(value, key, null, props, new InterpolationHelper.SubstitutionCallback() {
+                        public String getValue(String toSubstitute) {
+                            if (toSubstitute != null && toSubstitute.contains(":")) {
+                                String scheme = toSubstitute.substring(0, toSubstitute.indexOf(":"));
+                                return resolversSnapshot.get(scheme).resolve(fabricService, mutableConfigurations, pid, key, toSubstitute);
+                            }
+                            return substituteBundleProperty(toSubstitute, bundleContext);
                         }
-                        return substituteBundleProperty(toSubstitute, bundleContext);
-                    }
-                }));
-                } catch(EncryptionOperationNotPossibleException exception) {
+                    }));
+                } catch (EncryptionOperationNotPossibleException exception) {
                     LOGGER.warn("Error resolving " + key, exception);
                 }
             }

--- a/fabric/fabric-core/src/main/java/io/fabric8/service/FabricServiceImpl.java
+++ b/fabric/fabric-core/src/main/java/io/fabric8/service/FabricServiceImpl.java
@@ -93,6 +93,7 @@ import org.apache.felix.scr.annotations.Deactivate;
 import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.ReferencePolicy;
 import org.apache.felix.scr.annotations.Service;
+import org.jasypt.exceptions.EncryptionOperationNotPossibleException;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;


### PR DESCRIPTION
This fix just properly catch the exception and properly log it without printing stacktrace in output of mbean
'io.fabric8:type=Fabric/containers()'.