### PR TITLE
PATCH-2303: ENTESB-6855: Insight clients currently require access (unauthenticated) to multiple backend nodes

### DIFF
--- a/fabric/fabric8-karaf/pom.xml
+++ b/fabric/fabric8-karaf/pom.xml
@@ -212,6 +212,10 @@
            </dependency>
            <dependency>
                 <groupId>io.fabric8.insight</groupId>
+                <artifactId>insight-elasticsearch-auth-plugin</artifactId>
+           </dependency>
+           <dependency>
+                <groupId>io.fabric8.insight</groupId>
                 <artifactId>insight-elasticsearch-log-storage</artifactId>
            </dependency>
            <dependency>

--- a/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/insight/elasticsearch.basicauth.profile/io.fabric8.agent.properties
+++ b/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/insight/elasticsearch.basicauth.profile/io.fabric8.agent.properties
@@ -1,0 +1,19 @@
+#
+#  Copyright 2005-2014 Red Hat, Inc.
+#
+#  Red Hat licenses this file to you under the Apache License, version
+#  2.0 (the "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied.  See the License for the specific language governing
+#  permissions and limitations under the License.
+#
+
+attribute.parents=insight-core
+
+feature.insight-elasticsearch-auth=insight-elasticsearch-auth

--- a/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/insight/elasticsearch.node.profile/io.fabric8.elasticsearch-insight.properties
+++ b/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/insight/elasticsearch.node.profile/io.fabric8.elasticsearch-insight.properties
@@ -34,6 +34,9 @@ transport.tcp.port  = ${env:FABRIC8_ES_TCP_PORT}
 # Enable HTTP
 http.enabled = true
 
+# CORS allow headers
+http.cors.allow-headers=X-Requested-With,Content-Type,Content-Length,Authorization
+
 discovery.zookeeper.node=/fabric/registry/clusters/elasticsearch
 
 # Thread pools

--- a/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/insight/elasticsearch.node.profile/io.fabric8.elasticsearch-insight.properties#docker
+++ b/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/insight/elasticsearch.node.profile/io.fabric8.elasticsearch-insight.properties#docker
@@ -41,6 +41,9 @@ discovery.publish.port = ${env:FABRIC8_ES_TCP_PROXY_PORT}
 # Enable HTTP
 http.enabled = true
 
+# CORS allow headers
+http.cors.allow-headers=X-Requested-With,Content-Type,Content-Length,Authorization
+
 discovery.zookeeper.node=/fabric/registry/clusters/elasticsearch
 
 # Thread pools

--- a/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/insight/elasticsearch.node.profile/io.fabric8.elasticsearch-insight.properties#openshift
+++ b/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/insight/elasticsearch.node.profile/io.fabric8.elasticsearch-insight.properties#openshift
@@ -39,6 +39,9 @@ discovery.publish.port = ${env:OPENSHIFT_FUSE_ES_TCP_PROXY_PORT}
 # Enable HTTP
 http.enabled = true
 
+# CORS allow headers
+http.cors.allow-headers=X-Requested-With,Content-Type,Content-Length,Authorization
+
 discovery.zookeeper.node=/fabric/registry/clusters/elasticsearch
 
 # Thread pools

--- a/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/insight/elasticsearch.node.profile/io.fabric8.elasticsearch-insight.properties#openstack
+++ b/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/insight/elasticsearch.node.profile/io.fabric8.elasticsearch-insight.properties#openstack
@@ -35,6 +35,9 @@ transport.tcp.port  = ${env:FABRIC8_ES_TCP_PORT}
 # Enable HTTP
 http.enabled = true
 
+# CORS allow headers
+http.cors.allow-headers=X-Requested-With,Content-Type,Content-Length,Authorization
+
 discovery.zookeeper.node=/fabric/registry/clusters/elasticsearch
 
 # Thread pools

--- a/fabric/fabric8-karaf/src/main/resources/fabric-features.xml
+++ b/fabric/fabric8-karaf/src/main/resources/fabric-features.xml
@@ -462,13 +462,17 @@
         <feature version="${project.version}">insight-metrics</feature>
         <feature>fabric-zookeeper</feature>
         <feature>fabric-groups</feature>
-        <!--<feature>insight-kibana</feature>-->
         <bundle dependency="true">mvn:com.google.guava/guava/${guava-version}</bundle>
         <bundle>mvn:io.fabric8.insight/insight-storage/${project.version}</bundle>
         <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.elasticsearch/${elasticsearch-smx4-bundle.version}</bundle>
         <bundle>mvn:io.fabric8.insight/insight-elasticsearch-plugin/${project.version}</bundle>
         <bundle>mvn:io.fabric8.insight/insight-elasticsearch-discovery/${project.version}</bundle>
         <bundle>mvn:io.fabric8.insight/insight-elasticsearch-factory/${project.version}</bundle>
+    </feature>
+
+    <feature name="insight-elasticsearch-auth" version="${project.version}" resolver="(obr)">
+        <feature>insight-elasticsearch</feature>
+        <bundle>mvn:io.fabric8.insight/insight-elasticsearch-auth-plugin/${project.version}</bundle>
     </feature>
 
     <feature name="insight-elasticsearch-log-storage" version="${project.version}" resolver="(obr)">

--- a/insight/insight-elasticsearch-auth-plugin/pom.xml
+++ b/insight/insight-elasticsearch-auth-plugin/pom.xml
@@ -1,0 +1,162 @@
+<!--
+
+     Copyright 2005-2016 Red Hat, Inc.
+
+     Red Hat licenses this file to you under the Apache License, version
+     2.0 (the "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+     implied.  See the License for the specific language governing
+     permissions and limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>insight-project</artifactId>
+        <groupId>io.fabric8.insight</groupId>
+        <version>1.2.0.redhat-630-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>insight-elasticsearch-auth-plugin</artifactId>
+    <packaging>bundle</packaging>
+
+    <name>Fabric8 :: Insight :: Elastic Search Basc Http Auth Plugin</name>
+
+    <properties>
+        <fuse.osgi.import.additional>
+            !org.elasticsearch*,
+            *;resolution:=optional
+        </fuse.osgi.import.additional>
+        <fuse.osgi.export></fuse.osgi.export>
+        <fuse.osgi.private.pkg>
+            io.fabric8.insight.elasticsearch.plugin.*
+        </fuse.osgi.private.pkg>
+        <fuse.osgi.fragment.host>io.fabric8.insight.insight-elasticsearch-factory</fuse.osgi.fragment.host>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <elasticsearch.version>1.3.8</elasticsearch.version>
+        <lucene.version>4.9.0</lucene.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.elasticsearch</groupId>
+            <artifactId>elasticsearch</artifactId>
+            <version>${elasticsearch.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>org.apache.lucene</artifactId>
+                    <groupId>lucene-core</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>org.apache.lucene</artifactId>
+                    <groupId>lucene-analyzer-common</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>org.apache.lucene</artifactId>
+                    <groupId>lucene-queries</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>org.apache.lucene</artifactId>
+                    <groupId>lucene-analyzer-suggest</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>org.apache.lucene</artifactId>
+                    <groupId>lucene-misc</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- tests dependencies -->
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-test-framework</artifactId>
+            <version>${lucene.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-core</artifactId>
+            <version>${lucene.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-analyzers-common</artifactId>
+            <version>${lucene.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-queries</artifactId>
+            <version>${lucene.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-suggest</artifactId>
+            <version>${lucene.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-misc</artifactId>
+            <version>${lucene.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.elasticsearch</groupId>
+            <artifactId>elasticsearch</artifactId>
+            <version>${elasticsearch.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>-Djava.security.auth.login.config=${project.build.testOutputDirectory}${file.separator}testJaas.config</argLine>
+                    <systemPropertyVariables>
+                        <buildDirectory>${project.build.directory}</buildDirectory>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/insight/insight-elasticsearch-auth-plugin/src/main/java/io/fabric8/insight/elasticsearch/auth/plugin/HttpBasicServer.java
+++ b/insight/insight-elasticsearch-auth-plugin/src/main/java/io/fabric8/insight/elasticsearch/auth/plugin/HttpBasicServer.java
@@ -1,0 +1,244 @@
+/**
+ *  Copyright 2005-2016 Red Hat, Inc.
+ *
+ *  Red Hat licenses this file to you under the Apache License, version
+ *  2.0 (the "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *  implied.  See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+package io.fabric8.insight.elasticsearch.auth.plugin;
+
+import org.elasticsearch.common.Base64;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.http.HttpChannel;
+import org.elasticsearch.http.HttpRequest;
+import org.elasticsearch.http.HttpServer;
+import org.elasticsearch.http.HttpServerTransport;
+import org.elasticsearch.node.service.NodeService;
+import org.elasticsearch.rest.BytesRestResponse;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest.Method;
+
+import javax.security.auth.Subject;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.auth.login.AccountException;
+import javax.security.auth.login.FailedLoginException;
+import javax.security.auth.login.LoginContext;
+import javax.security.auth.login.LoginException;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.security.Principal;
+import java.util.Arrays;
+
+import static org.elasticsearch.rest.RestStatus.OK;
+import static org.elasticsearch.rest.RestStatus.UNAUTHORIZED;
+
+public class HttpBasicServer extends HttpServer {
+
+    private static final String HEADER_WWW_AUTHENTICATE = "WWW-Authenticate";
+    private static final String HEADER_AUTHORIZATION = "Authorization";
+    private static final String AUTHENTICATION_SCHEME_BASIC = "Basic";
+
+    private String realm;
+    private String[] roles;
+    private final boolean log;
+
+    @Inject
+    public HttpBasicServer(Settings settings, Environment environment, HttpServerTransport transport,
+            RestController restController,
+            NodeService nodeService) {
+        super(settings, environment, transport, restController, nodeService);
+
+        this.realm = settings.get("http.basic.realm", "karaf");
+        this.roles = settings.getAsArray("http.basic.roles", new String[]{"admin", "manager", "viewer", "Monitor", "Operator", "Maintainer", "Deployer", "Auditor", "Administrator", "SuperUser"});
+        this.log = settings.getAsBoolean("http.basic.log", false);
+        Loggers.getLogger(getClass()).info("using realm: [{}] and authorized roles: [{}]",
+                realm, roles);
+    }
+
+    @Override
+    public void internalDispatchRequest(final HttpRequest request, final HttpChannel channel) {
+        if (log) {
+          logRequest(request);
+        }
+        // allow health check even without authorization
+        if (healthCheck(request)) {
+            channel.sendResponse(new BytesRestResponse(OK, "{\"OK\":{}}"));
+        } else if (authorized(request)) {
+            super.internalDispatchRequest(request, channel);
+        } else {
+          logUnAuthorizedRequest(request);
+          BytesRestResponse response = new BytesRestResponse(UNAUTHORIZED, "Authentication Required");
+          response.addHeader(HEADER_WWW_AUTHENTICATE, "Basic realm=\"" + this.realm + "\"");
+          channel.sendResponse(response);
+        }
+    }
+
+    private boolean healthCheck(final HttpRequest request) {
+        String path = request.path();
+        return (request.method() == Method.GET) && path.equals("/");
+    }
+
+    private boolean authorized(final HttpRequest request) {
+      return allowOptionsForCORS(request) || authBasic(request);
+    }
+
+    public String getDecodedAuthHeader(HttpRequest request) {
+        String authHeader = request.header(HEADER_AUTHORIZATION);
+        if (authHeader != null && authHeader.length() > 0) {
+
+            // Get the authType (Basic, Digest) and authInfo (user/password)
+            // from the header
+            authHeader = authHeader.trim();
+            int blank = authHeader.indexOf(' ');
+            if (blank > 0) {
+                String authType = authHeader.substring(0, blank);
+                String authInfo = authHeader.substring(blank).trim();
+
+                // Check whether authorization type matches
+                if (authType.equalsIgnoreCase(AUTHENTICATION_SCHEME_BASIC)) {
+                    try {
+                        return new String(Base64.decode(authInfo));
+                    } catch (IOException e) {
+                        logger.debug("Http Basic credentials: [{}] impossible to base 64 decode.", authInfo);
+                        return "";
+                    }
+                } else {
+                    logger.debug("Http Basic authentication Schema: [{}] not supported only [{}] is supported.", authType, AUTHENTICATION_SCHEME_BASIC);
+                    return "";
+                }
+            } else {
+                logger.debug("Http Basic authentication Header: [{}] impossible to base 64 decode.", authHeader);
+                return "";
+            }
+        } else {
+            logger.debug("Http Basic authentication Header: [{}] not  present.", HEADER_AUTHORIZATION);
+            return "";
+        }
+    }
+
+    private boolean authBasic(final HttpRequest request) {
+        String decodedAuthHeader = getDecodedAuthHeader(request);
+        if (!decodedAuthHeader.isEmpty()) {
+            String[] userAndPassword = decodedAuthHeader.split(":", 2);
+            String givenUser = userAndPassword[0];
+            String givenPass = userAndPassword[1];
+
+            // authenticate
+            Subject subject = doAuthenticate(givenUser, givenPass);
+            if (subject != null) {
+                // succeed
+                return true;
+            }
+        }
+        //failed
+        return false;
+    }
+
+    private Subject doAuthenticate(final String username, final String password) {
+        try {
+            Subject subject = new Subject();
+            LoginContext loginContext = new LoginContext(realm, subject, new CallbackHandler() {
+                public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+                    for (int i = 0; i < callbacks.length; i++) {
+                        if (callbacks[i] instanceof NameCallback) {
+                            ((NameCallback) callbacks[i]).setName(username);
+                        } else if (callbacks[i] instanceof PasswordCallback) {
+                            ((PasswordCallback) callbacks[i]).setPassword(password.toCharArray());
+                        } else {
+                            throw new UnsupportedCallbackException(callbacks[i]);
+                        }
+                    }
+                }
+            });
+            loginContext.login();
+            logger.debug("Login successful: {}", subject.toString());
+            boolean found = false;
+            for (String role : roles) {
+                if (role != null && role.length() > 0 && !found) {
+                    String roleName = role.trim();
+                    int idx = roleName.indexOf(':');
+                    if (idx > 0) {
+                        roleName = roleName.substring(idx + 1);
+                    }
+
+                    for (Principal p : subject.getPrincipals()) {
+                        logger.debug("Principal found in real: {}", p.getName() );
+                        if (p.getName().equals(roleName)) {
+                            found = true;
+                            break;
+                        }
+                    }
+
+                }
+            }
+            if (!found) {
+                throw new FailedLoginException("User does not have the required role " + Arrays.asList(roles));
+            }
+
+            return subject;
+        } catch (AccountException e) {
+            logger.warn("Account failure {}", e.getMessage());
+            return null;
+        } catch (LoginException e) {
+            logger.debug("Login failed {}", e.getMessage());
+            return null;
+        }
+    }
+
+    private boolean allowOptionsForCORS(HttpRequest request) {
+        // https://en.wikipedia.org/wiki/Cross-origin_resource_sharing the
+        // specification mandates that browsers “preflight” the request, soliciting
+        // supported methods from the server with an HTTP OPTIONS request
+        // in elasticsearch.yml set
+        // http.cors.allow-headers: "X-Requested-With, Content-Type, Content-Length, Authorization"
+        if (request.method() == Method.OPTIONS) {
+            logger.debug("CORS type {}, address {}, path {}, request {}, content {}",
+                    request.method(), getAddress(request), request.path(), request.params(), request.content().toUtf8());
+            return true;
+        }
+        return false;
+    }
+
+    private void logRequest(final HttpRequest request) {
+      String addr = getAddress(request).getHostAddress();
+      String t = "Authorization:{}, Host:{}, Path:{}, Request-IP:{}, " +
+        "Client-IP:{}, X-Client-IP{}";
+      logger.info(t,
+                  request.header("Authorization"),
+                  request.header("Host"),
+                  request.path(),
+                  addr,
+                  request.header("X-Client-IP"),
+                  request.header("Client-IP"));
+    }
+
+    private void logUnAuthorizedRequest(final HttpRequest request) {
+        String addr = getAddress(request).getHostAddress();
+        String t = "UNAUTHORIZED type:{}, address:{}, path:{}, request:{},"
+          + "content:{}, credentials:{}";
+        logger.warn(t,
+                request.method(), addr, request.path(), request.params(),
+                request.content().toUtf8(), getDecodedAuthHeader(request));
+    }
+
+    private InetAddress getAddress(HttpRequest request) {
+        return ((InetSocketAddress) request.getRemoteAddress()).getAddress();
+    }
+
+}

--- a/insight/insight-elasticsearch-auth-plugin/src/main/java/io/fabric8/insight/elasticsearch/auth/plugin/HttpBasicServerModule.java
+++ b/insight/insight-elasticsearch-auth-plugin/src/main/java/io/fabric8/insight/elasticsearch/auth/plugin/HttpBasicServerModule.java
@@ -1,0 +1,31 @@
+/**
+ *  Copyright 2005-2016 Red Hat, Inc.
+ *
+ *  Red Hat licenses this file to you under the Apache License, version
+ *  2.0 (the "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *  implied.  See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+package io.fabric8.insight.elasticsearch.auth.plugin;
+
+import org.elasticsearch.http.HttpServerModule;
+import org.elasticsearch.common.settings.Settings;
+
+public class HttpBasicServerModule extends HttpServerModule {
+    
+    public HttpBasicServerModule(Settings settings) {
+        super(settings);
+    }
+    
+    @Override protected void configure() {
+        bind(HttpBasicServer.class).asEagerSingleton();
+    }
+}
+

--- a/insight/insight-elasticsearch-auth-plugin/src/main/java/io/fabric8/insight/elasticsearch/auth/plugin/HttpBasicServerPlugin.java
+++ b/insight/insight-elasticsearch-auth-plugin/src/main/java/io/fabric8/insight/elasticsearch/auth/plugin/HttpBasicServerPlugin.java
@@ -1,0 +1,71 @@
+/**
+ *  Copyright 2005-2016 Red Hat, Inc.
+ *
+ *  Red Hat licenses this file to you under the Apache License, version
+ *  2.0 (the "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *  implied.  See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+package io.fabric8.insight.elasticsearch.auth.plugin;
+
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Module;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.plugins.AbstractPlugin;
+import org.elasticsearch.common.component.LifecycleComponent;
+import org.elasticsearch.common.settings.ImmutableSettings;
+
+import java.util.Collection;
+
+import static org.elasticsearch.common.collect.Lists.*;
+
+public class HttpBasicServerPlugin extends AbstractPlugin {
+
+    private boolean enabledByDefault = true;
+    private final Settings settings;
+
+    @Inject public HttpBasicServerPlugin(Settings settings) {
+        this.settings = settings;
+    }
+
+    @Override public String name() {
+        return "fabric8-http-basic-plugin";
+    }
+
+    @Override public String description() {
+        return "HTTP Basic Server Plugin for fabric8 v1";
+    }
+
+    @Override public Collection<Class<? extends Module>> modules() {
+        Collection<Class<? extends Module>> modules = newArrayList();
+        if (settings.getAsBoolean("http.basic.enabled", enabledByDefault)) {
+            modules.add(HttpBasicServerModule.class);
+        }
+        return modules;
+    }
+
+    @Override public Collection<Class<? extends LifecycleComponent>> services() {
+        Collection<Class<? extends LifecycleComponent>> services = newArrayList();
+        if (settings.getAsBoolean("http.basic.enabled", enabledByDefault)) {
+            services.add(HttpBasicServer.class);
+        }
+        return services;
+    }
+
+    @Override public Settings additionalSettings() {
+        if (settings.getAsBoolean("http.basic.enabled", enabledByDefault)) {
+            return ImmutableSettings.settingsBuilder().
+                    put("http.enabled", false).                    
+                    build();
+        } else {
+            return ImmutableSettings.Builder.EMPTY_SETTINGS;
+        }
+    }
+}

--- a/insight/insight-elasticsearch-auth-plugin/src/main/resources/es-plugin.properties
+++ b/insight/insight-elasticsearch-auth-plugin/src/main/resources/es-plugin.properties
@@ -1,0 +1,17 @@
+#
+#  Copyright 2005-2016 Red Hat, Inc.
+#
+#  Red Hat licenses this file to you under the Apache License, version
+#  2.0 (the "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied.  See the License for the specific language governing
+#  permissions and limitations under the License.
+#
+
+plugin=io.fabric8.insight.elasticsearch.auth.plugin.HttpBasicServerPlugin

--- a/insight/insight-elasticsearch-auth-plugin/src/test/java/io/fabric8/insight/elasticsearch/auth/plugin/auth/integration/AbstractElasticsearchAuthPluginTest.java
+++ b/insight/insight-elasticsearch-auth-plugin/src/test/java/io/fabric8/insight/elasticsearch/auth/plugin/auth/integration/AbstractElasticsearchAuthPluginTest.java
@@ -1,0 +1,53 @@
+/**
+ *  Copyright 2005-2016 Red Hat, Inc.
+ *
+ *  Red Hat licenses this file to you under the Apache License, version
+ *  2.0 (the "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *  implied.  See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+package io.fabric8.insight.elasticsearch.auth.plugin.auth.integration;
+
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.rest.client.http.HttpGetWithEntity;
+import org.elasticsearch.test.rest.client.http.HttpRequestBuilder;
+
+import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class AbstractElasticsearchAuthPluginTest extends ElasticsearchIntegrationTest {
+    public static final String DEFAULT_DATA_DIRECTORY = System.getProperty("buildDirectory")+ File.separator+"elasticsearch-data";
+    public static final String PROTOCOL = "http";
+    public static final String HOST = "localhost";
+    public static final int PORT = 9200;
+    public static final String STATUS_PATH = "/_status";
+
+    protected static HttpRequestBuilder httpClient() {
+        return new HttpRequestBuilder(HttpClients.createDefault()).host(HOST).port(PORT);
+    }
+
+    protected static HttpUriRequest httpRequest() {
+        HttpUriRequest httpUriRequest = null;
+        try {
+            httpUriRequest = new HttpGetWithEntity(new URI(PROTOCOL, null, HOST, PORT, STATUS_PATH, null, null));
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException(e);
+        }
+        return httpUriRequest;
+    }
+
+    protected static CloseableHttpClient closeableHttpClient() {
+        return HttpClients.createDefault();
+    }
+}

--- a/insight/insight-elasticsearch-auth-plugin/src/test/java/io/fabric8/insight/elasticsearch/auth/plugin/auth/integration/CustomRealmIntegrationTest.java
+++ b/insight/insight-elasticsearch-auth-plugin/src/test/java/io/fabric8/insight/elasticsearch/auth/plugin/auth/integration/CustomRealmIntegrationTest.java
@@ -1,0 +1,32 @@
+/**
+ *  Copyright 2005-2016 Red Hat, Inc.
+ *
+ *  Red Hat licenses this file to you under the Apache License, version
+ *  2.0 (the "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *  implied.  See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+package io.fabric8.insight.elasticsearch.auth.plugin.auth.integration;
+
+import io.fabric8.insight.elasticsearch.auth.plugin.HttpBasicServerPlugin;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+
+public class CustomRealmIntegrationTest extends DefaultConfigurationIntegrationTest {
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return ImmutableSettings.settingsBuilder()
+                .put("http.basic.realm", "another")
+                .put("plugin.types", HttpBasicServerPlugin.class.getName())
+                .put("path.data", DEFAULT_DATA_DIRECTORY)
+                .build();
+    }
+}

--- a/insight/insight-elasticsearch-auth-plugin/src/test/java/io/fabric8/insight/elasticsearch/auth/plugin/auth/integration/CustomRolesIntegrationTest.java
+++ b/insight/insight-elasticsearch-auth-plugin/src/test/java/io/fabric8/insight/elasticsearch/auth/plugin/auth/integration/CustomRolesIntegrationTest.java
@@ -1,0 +1,50 @@
+/**
+ *  Copyright 2005-2016 Red Hat, Inc.
+ *
+ *  Red Hat licenses this file to you under the Apache License, version
+ *  2.0 (the "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *  implied.  See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+package io.fabric8.insight.elasticsearch.auth.plugin.auth.integration;
+
+import io.fabric8.insight.elasticsearch.auth.plugin.HttpBasicServerPlugin;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.elasticsearch.common.Base64;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
+import org.junit.Test;
+
+@ClusterScope(transportClientRatio = 0.0, scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+public class CustomRolesIntegrationTest extends AbstractElasticsearchAuthPluginTest {
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return ImmutableSettings.settingsBuilder()
+                .put("http.basic.roles", "admin,testRole")
+                .put("plugin.types", HttpBasicServerPlugin.class.getName())
+                .put("path.data", DEFAULT_DATA_DIRECTORY)
+                .build();
+    }
+
+    @Test
+    public void hasRightRoleBasicAuthenticated() throws Exception {
+        HttpUriRequest request = httpRequest();
+        String credentials = "user:admin";
+        request.setHeader("Authorization", "Basic " + Base64.encodeBytes(credentials.getBytes()));
+        CloseableHttpResponse response = closeableHttpClient().execute(request);
+        assertEquals(RestStatus.OK.getStatus(), response.getStatusLine().getStatusCode());
+    }
+
+}

--- a/insight/insight-elasticsearch-auth-plugin/src/test/java/io/fabric8/insight/elasticsearch/auth/plugin/auth/integration/DefaultConfigurationIntegrationTest.java
+++ b/insight/insight-elasticsearch-auth-plugin/src/test/java/io/fabric8/insight/elasticsearch/auth/plugin/auth/integration/DefaultConfigurationIntegrationTest.java
@@ -1,0 +1,81 @@
+/**
+ *  Copyright 2005-2016 Red Hat, Inc.
+ *
+ *  Red Hat licenses this file to you under the Apache License, version
+ *  2.0 (the "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *  implied.  See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+package io.fabric8.insight.elasticsearch.auth.plugin.auth.integration;
+
+
+import io.fabric8.insight.elasticsearch.auth.plugin.HttpBasicServerPlugin;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.elasticsearch.common.Base64;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
+import org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
+import org.elasticsearch.test.rest.client.http.HttpResponse;
+import org.junit.Test;
+
+@ClusterScope(transportClientRatio = 0.0, scope = Scope.SUITE, numDataNodes = 1)
+public class DefaultConfigurationIntegrationTest extends AbstractElasticsearchAuthPluginTest {
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return ImmutableSettings.settingsBuilder()
+                .put("plugin.types", HttpBasicServerPlugin.class.getName())
+                .put("path.data", DEFAULT_DATA_DIRECTORY)
+                .build();
+    }
+
+    @Test
+    public void testHealthCheck() throws Exception {
+        HttpResponse response = httpClient().path("/").execute();
+        assertEquals(RestStatus.OK.getStatus(), response.getStatusCode());
+    }
+
+    @Test
+    public void notAuthenticated() throws Exception {
+        HttpResponse response = httpClient().path(STATUS_PATH).execute();
+        assertEquals(RestStatus.UNAUTHORIZED.getStatus(), response.getStatusCode());
+    }
+
+    @Test
+    public void isBasicAuthenticated() throws Exception {
+        HttpUriRequest request = httpRequest();
+        String credentials = "admin:admin";
+        request.setHeader("Authorization", "Basic " + Base64.encodeBytes(credentials.getBytes()));
+        CloseableHttpResponse response = closeableHttpClient().execute(request);
+        assertEquals(RestStatus.OK.getStatus(), response.getStatusLine().getStatusCode());
+    }
+
+    @Test
+    public void isWronglyBasicAuthenticated() throws Exception {
+        HttpUriRequest request = httpRequest();
+        String credentials = "admin:12345";
+        request.setHeader("Authorization", "Basic " + Base64.encodeBytes(credentials.getBytes()));
+        CloseableHttpResponse response = closeableHttpClient().execute(request);
+        assertEquals(RestStatus.UNAUTHORIZED.getStatus(), response.getStatusLine().getStatusCode());
+    }
+
+    @Test
+    public void hasWrongRoleBasicAuthenticated() throws Exception {
+        HttpUriRequest request = httpRequest();
+        String credentials = "user:admin";
+        request.setHeader("Authorization", "Basic " + Base64.encodeBytes(credentials.getBytes()));
+        CloseableHttpResponse response = closeableHttpClient().execute(request);
+        assertEquals(RestStatus.UNAUTHORIZED.getStatus(), response.getStatusLine().getStatusCode());
+    }
+
+}

--- a/insight/insight-elasticsearch-auth-plugin/src/test/java/io/fabric8/insight/elasticsearch/auth/plugin/auth/integration/jaas/TestGroup.java
+++ b/insight/insight-elasticsearch-auth-plugin/src/test/java/io/fabric8/insight/elasticsearch/auth/plugin/auth/integration/jaas/TestGroup.java
@@ -1,0 +1,55 @@
+/**
+ *  Copyright 2005-2016 Red Hat, Inc.
+ *
+ *  Red Hat licenses this file to you under the Apache License, version
+ *  2.0 (the "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *  implied.  See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+package io.fabric8.insight.elasticsearch.auth.plugin.auth.integration.jaas;
+
+import java.security.Principal;
+
+public class TestGroup implements Principal {
+    private final String name;
+
+    public TestGroup(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        TestGroup other = (TestGroup) obj;
+        if (name == null) {
+            if (other.name != null)
+                return false;
+        } else if (!name.equals(other.name))
+            return false;
+        return true;
+    }
+}

--- a/insight/insight-elasticsearch-auth-plugin/src/test/java/io/fabric8/insight/elasticsearch/auth/plugin/auth/integration/jaas/TestLoginModule.java
+++ b/insight/insight-elasticsearch-auth-plugin/src/test/java/io/fabric8/insight/elasticsearch/auth/plugin/auth/integration/jaas/TestLoginModule.java
@@ -1,0 +1,163 @@
+/**
+ *  Copyright 2005-2016 Red Hat, Inc.
+ *
+ *  Red Hat licenses this file to you under the Apache License, version
+ *  2.0 (the "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *  implied.  See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+package io.fabric8.insight.elasticsearch.auth.plugin.auth.integration.jaas;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.security.auth.Subject;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.auth.login.FailedLoginException;
+import javax.security.auth.login.LoginException;
+import javax.security.auth.spi.LoginModule;
+import java.io.IOException;
+import java.security.Principal;
+import java.util.Map;
+
+public class TestLoginModule implements LoginModule {
+    private static final Logger LOGGER = LoggerFactory.getLogger(TestLoginModule.class);
+    public static final String USER1 = "admin";
+    public static final String PASSWORD1 = "admin";
+    public static final String ROLES1 = "admin,testRole";
+    public static final String USER2 = "user";
+    public static final String ROLES2 = "testRole";
+
+    private Map<String, String> options;
+    private CallbackHandler callbackHandler;
+    private Map<String, String> sharedState;
+    private Subject subject;
+
+    private String name;
+    private String password;
+    private boolean succeeded;
+
+    private TestPrincipal principal;
+
+    public void initialize(Subject subject, CallbackHandler callbackHandler, Map<String, ?> sharedState, Map<String, ?> options) {
+        this.subject = subject;
+        this.callbackHandler = callbackHandler;
+        this.sharedState = (Map<String, String>) sharedState;
+        this.options = (Map<String, String>) options;
+    }
+
+    public boolean login() throws LoginException {
+        String user = null;
+        try {
+            Callback[] callbacks = new Callback[2];
+            callbacks[0] = new NameCallback("Username: ");
+            callbacks[1] = new PasswordCallback("Password: ", false);
+            try {
+                callbackHandler.handle(callbacks);
+            } catch (IOException ioe) {
+                throw new LoginException(ioe.getMessage());
+            } catch (UnsupportedCallbackException uce) {
+                throw new LoginException(uce.getMessage() + " not available to obtain information from user");
+            }
+
+            user = ((NameCallback) callbacks[0]).getName();
+            if (user == null)
+                throw new FailedLoginException("user name is null");
+
+            this.name = user;
+
+            char[] tmpPassword = ((PasswordCallback) callbacks[1]).getPassword();
+            if (tmpPassword == null) {
+                tmpPassword = new char[0];
+            }
+
+            this.password = new String( tmpPassword );
+
+            // verify the username/password
+            boolean usernameCorrect = false;
+            if (name.equals(USER1) || name.equals(USER2)) {
+                usernameCorrect = true;
+            }
+            if (usernameCorrect && (password.equals(PASSWORD1))) {
+                succeeded = true;
+                return true;
+            } else {
+                succeeded = false;
+                name = null;
+                password = null;
+                if (!usernameCorrect) {
+                    throw new FailedLoginException("User Name Incorrect");
+                } else {
+                    throw new FailedLoginException("Password Incorrect");
+                }
+            }
+        } catch (LoginException ex) {
+            LOGGER.info("Login failed {}", user, ex);
+            throw ex;
+        }
+    }
+
+    public boolean commit() throws LoginException {
+        boolean commit = false;
+        if (succeeded == false) {
+            return commit;
+        } else {
+            commit = true;
+            // First we authenticate the user
+            principal = new TestPrincipal(name);
+            commit &= subject.getPrincipals().add(principal);
+
+            // Then we try to authorize him with roles
+            String rolesAsString = "";
+            if (USER1.equals(this.name)) {
+                rolesAsString = ROLES1;
+            } else if (USER2.equals(this.name)) {
+                rolesAsString = ROLES2;
+            }
+
+            String[] roles = rolesAsString.split(",\\s*");
+            for (String roleName : roles) {
+                Principal role = new TestGroup(roleName);
+                LOGGER.info("adding role {}", roleName);
+                commit &= subject.getPrincipals().add(role);
+            }
+
+            LOGGER.info("user {} was assigned roles: {}", name, rolesAsString);
+        }
+
+        //clean state
+        succeeded = false;
+        name = null;
+        password = null;
+
+        return commit;
+    }
+
+    public boolean abort() throws LoginException {
+        //not needed for test purposes
+        return false;
+    }
+
+    public boolean logout() throws LoginException {
+        if (subject != null) {
+            if (principal != null) {
+                subject.getPrincipals().remove(principal);
+            }
+        }
+        succeeded = false;
+        name = null;
+        password = null;
+        return true;
+    }
+}

--- a/insight/insight-elasticsearch-auth-plugin/src/test/java/io/fabric8/insight/elasticsearch/auth/plugin/auth/integration/jaas/TestPrincipal.java
+++ b/insight/insight-elasticsearch-auth-plugin/src/test/java/io/fabric8/insight/elasticsearch/auth/plugin/auth/integration/jaas/TestPrincipal.java
@@ -1,0 +1,55 @@
+/**
+ *  Copyright 2005-2016 Red Hat, Inc.
+ *
+ *  Red Hat licenses this file to you under the Apache License, version
+ *  2.0 (the "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *  implied.  See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+package io.fabric8.insight.elasticsearch.auth.plugin.auth.integration.jaas;
+
+import java.security.Principal;
+
+public class TestPrincipal implements Principal {
+    private final String name;
+
+    public TestPrincipal(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        TestPrincipal other = (TestPrincipal) obj;
+        if (name == null) {
+            if (other.name != null)
+                return false;
+        } else if (!name.equals(other.name))
+            return false;
+        return true;
+    }
+}

--- a/insight/insight-elasticsearch-auth-plugin/src/test/resources/log4j.properties
+++ b/insight/insight-elasticsearch-auth-plugin/src/test/resources/log4j.properties
@@ -1,0 +1,24 @@
+#
+#  Copyright 2005-2016 Red Hat, Inc.
+#
+#  Red Hat licenses this file to you under the Apache License, version
+#  2.0 (the "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied.  See the License for the specific language governing
+#  permissions and limitations under the License.
+#
+
+log4j.rootLogger=info, console
+
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n
+
+log4j.logger.io.fabric8.insight.elasticsearch.auth.plugin=debug
+log4j.logger.org.elasticsearch.io.fabric8.insight.elasticsearch.auth.plugin=debug

--- a/insight/insight-elasticsearch-auth-plugin/src/test/resources/testJaas.config
+++ b/insight/insight-elasticsearch-auth-plugin/src/test/resources/testJaas.config
@@ -1,0 +1,22 @@
+/**
+ *  Copyright 2005-2016 Red Hat, Inc.
+ *
+ *  Red Hat licenses this file to you under the Apache License, version
+ *  2.0 (the "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *  implied.  See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+karaf {
+  io.fabric8.insight.elasticsearch.auth.plugin.auth.integration.jaas.TestLoginModule required debug=true;
+};
+another {
+  io.fabric8.insight.elasticsearch.auth.plugin.auth.integration.jaas.TestLoginModule required debug=true;
+};

--- a/insight/pom.xml
+++ b/insight/pom.xml
@@ -52,6 +52,7 @@
     <module>insight-elasticsearch-discovery</module>
     <module>insight-elasticsearch-log-storage</module>
     <module>insight-elasticsearch-metrics-storage</module>
+    <module>insight-elasticsearch-auth-plugin</module>
   </modules>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,7 @@
         <hawtbuf-version>1.11.0.redhat-1</hawtbuf-version>
         <hawtdispatch-version>1.22</hawtdispatch-version>
         <hawtio-dockerui-version>1.0.4</hawtio-dockerui-version>
-        <hawtio-eshead-version>1.0.3</hawtio-eshead-version>
+        <hawtio-eshead-version>1.0.4</hawtio-eshead-version>
         <hawtio-kibana-version>3.1.2_3</hawtio-kibana-version>
         <hawtio-swagger-version>${hawtio-version}</hawtio-swagger-version>
         <hawtio-version>1.4.0.redhat-630283</hawtio-version>
@@ -994,6 +994,11 @@
             </dependency>
             <dependency>
                 <groupId>io.fabric8.insight</groupId>
+                <artifactId>insight-elasticsearch-auth-plugin</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.fabric8.insight</groupId>
                 <artifactId>insight-elasticsearch-log-storage</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -1266,7 +1271,6 @@
                 <artifactId>jasypt</artifactId>
                 <version>${jasypt-version}</version>
             </dependency>
-
             <!-- OPS4J -->
             <dependency>
                 <groupId>org.ops4j.pax.exam</groupId>
@@ -2567,6 +2571,22 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <dependency>
+                <groupId>org.elasticsearch</groupId>
+                <artifactId>elasticsearch</artifactId>
+                <type>test-jar</type>
+                <version>${elasticsearch-version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.ow2.asm</groupId>
+                        <artifactId>asm</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.ow2.asm</groupId>
+                        <artifactId>asm-commons</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
 
             <dependency>
                 <groupId>org.jolokia</groupId>
@@ -2920,6 +2940,14 @@
                 <groupId>joda-time</groupId>
                 <artifactId>joda-time</artifactId>
                 <version>${joda-time2-version}</version>
+            </dependency>
+
+            <!-- Hamcrest all -->
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-all</artifactId>
+                <version>1.3</version>
+                <scope>test</scope>
             </dependency>
 
         </dependencies>


### PR DESCRIPTION
Added support for basic http authentication (using elasticsearch plugins system) over fabric jaas realms.