### PR TITLE
ENTESB-7691: EnsembleAdd throw exception with upperCase

### DIFF
--- a/fabric/fabric-core/src/main/java/io/fabric8/internal/ZooKeeperClusterServiceImpl.java
+++ b/fabric/fabric-core/src/main/java/io/fabric8/internal/ZooKeeperClusterServiceImpl.java
@@ -463,8 +463,6 @@ public final class ZooKeeperClusterServiceImpl extends AbstractComponent impleme
             for (String c : containers) {
                 if (current.contains(c)) {
                     throw new EnsembleModificationFailed("Container " + c + " is already part of the ensemble." , EnsembleModificationFailed.Reason.CONTAINERS_ALREADY_IN_ENSEMBLE);
-                } else if (!c.equals(c.toLowerCase())) {
-                    throw new EnsembleModificationFailed("Only lower case names are supported for containers. Current name: " + c , EnsembleModificationFailed.Reason.INVALID_ARGUMENTS);
                 } else {
                     current.add(c);
                 }


### PR DESCRIPTION
Ensemble Add throwing exception:Error executing command: Only lower case names are supported for containers. Current name: fabricRoot1