### PR TITLE
[PATCH-2606] ENTESB-7902 - One of the child-container is too slow, heapdump show few threads each with 90 Mb of org.json.simple.JSONArray object

### DIFF
--- a/fabric/fabric-jolokia/pom.xml
+++ b/fabric/fabric-jolokia/pom.xml
@@ -68,6 +68,10 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
         
         <!-- Provided Dependencies -->
         <dependency>

--- a/fabric/fabric-jolokia/src/main/java/io/fabric8/jolokia/FabricJolokia.java
+++ b/fabric/fabric-jolokia/src/main/java/io/fabric8/jolokia/FabricJolokia.java
@@ -63,7 +63,6 @@ public class FabricJolokia extends AbstractComponent {
         configurer.configure(properties, this);
         context = new JolokiaSecureHttpContext(realm, role);
         Hashtable<String,String> initProps = new Hashtable<>();
-        //initProps.put("restrictorClass", RBACRestrictor.class.getName()); // This requires Jolokia 1.3.3
         injectSystemProperties(initProps);
         httpService.get().registerServlet(getServletAlias(), new JolokiaServlet(bundleContext){
             @Override

--- a/fabric/fabric-jolokia/src/main/java/io/fabric8/jolokia/RBACMBeanInvoker.java
+++ b/fabric/fabric-jolokia/src/main/java/io/fabric8/jolokia/RBACMBeanInvoker.java
@@ -1,0 +1,313 @@
+/*
+ *  Copyright 2018 Red Hat, Inc.
+ *
+ *  Red Hat licenses this file to you under the Apache License, version
+ *  2.0 (the "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *  implied.  See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+package io.fabric8.jolokia;
+
+import java.lang.management.ManagementFactory;
+import java.security.AccessControlContext;
+import java.security.AccessController;
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import javax.management.InstanceNotFoundException;
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanInfo;
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import javax.security.auth.Subject;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Cached MBean server invoker for {@link RBACRestrictor}.
+ */
+public class RBACMBeanInvoker {
+
+    private static final transient Logger LOG = LoggerFactory.getLogger(RBACMBeanInvoker.class);
+
+    /**
+     * The length of time (in minutes) an entry in canInvokeCache is valid after creation
+     */
+    private static long CAN_INVOKE_CACHE_DURATION = 10;
+
+    /**
+     * The length of time (in minutes) an entry in mbeanInfoCache is valid after creation
+     */
+    private static long MBEAN_INFO_CACHE_DURATION = 10;
+
+    protected MBeanServer mBeanServer;
+    protected ObjectName securityMBean;
+
+    protected LoadingCache<CanInvokeKey, Boolean> canInvokeCache;
+    protected LoadingCache<ObjectName, Map<String, MBeanAttributeInfo>> mbeanInfoCache;
+
+    protected class CanInvokeKey {
+        protected String username;
+        protected ObjectName objectName;
+        protected String operation;
+
+        protected CanInvokeKey(String username, ObjectName objectName, String operation) {
+            this.username = username;
+            this.objectName = objectName;
+            this.operation = operation;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (!(obj instanceof CanInvokeKey)) {
+                return false;
+            }
+            CanInvokeKey key = (CanInvokeKey) obj;
+            return Objects.equals(username, key.username)
+                && Objects.equals(objectName, key.objectName)
+                && Objects.equals(operation, key.operation);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(username, objectName, operation);
+        }
+
+        @Override
+        public String toString() {
+            return String.format("%s{username=%s, objectName=%s, operation=%s}",
+                getClass().getSimpleName(),
+                Objects.toString(username),
+                Objects.toString(objectName),
+                Objects.toString(operation));
+        }
+    }
+
+    public RBACMBeanInvoker() {
+        initSecurityMBean();
+        initCaches();
+    }
+
+    protected void initSecurityMBean() {
+        this.mBeanServer = ManagementFactory.getPlatformMBeanServer();
+        Set<ObjectName> mbeans = new HashSet<>();
+        try {
+            mbeans = mBeanServer.queryNames(new ObjectName("*:type=security,area=jmx,*"), null);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Found JMXSecurity MBeans: {}", mbeans);
+            }
+        } catch (MalformedObjectNameException e) {
+            LOG.error(e.getMessage(), e);
+        }
+        if (mbeans.isEmpty()) {
+            LOG.info("Didn't discover any JMXSecurity MBeans, role based access control is disabled");
+            this.securityMBean = null;
+            return;
+        }
+
+        ObjectName chosen = chooseMBean(mbeans);
+        LOG.info("Using MBean [{}] for role based access control", chosen);
+        this.securityMBean = chosen;
+    }
+
+    private static ObjectName chooseMBean(Set<ObjectName> mbeans) {
+        if (mbeans.size() == 1) {
+            return mbeans.iterator().next();
+        }
+        for (ObjectName mbean : mbeans) {
+            if (!isHawtioDummy(mbean.toString())) {
+                return mbean;
+            }
+        }
+        return null;
+    }
+
+    private static boolean isHawtioDummy(String name) {
+        return name.contains("HawtioDummy");
+    }
+
+    protected void initCaches() {
+        this.canInvokeCache = CacheBuilder.newBuilder()
+            .expireAfterWrite(CAN_INVOKE_CACHE_DURATION, TimeUnit.MINUTES)
+            .build(new CacheLoader<CanInvokeKey, Boolean>() {
+                @Override
+                public Boolean load(CanInvokeKey key) throws Exception {
+                    LOG.debug("Do invoking canInvoke() for {}", key);
+                    return doCanInvoke(key.objectName, key.operation);
+                }
+            });
+        this.mbeanInfoCache = CacheBuilder.newBuilder()
+            .expireAfterWrite(MBEAN_INFO_CACHE_DURATION, TimeUnit.MINUTES)
+            .build(new CacheLoader<ObjectName, Map<String, MBeanAttributeInfo>>() {
+                @Override
+                public Map<String, MBeanAttributeInfo> load(ObjectName objectName) throws Exception {
+                    LOG.debug("Do loading MBean attributes for {}", objectName);
+                    return loadMBeanAttributes(objectName);
+                }
+            });
+    }
+
+    protected boolean doCanInvoke(ObjectName objectName, String operation) throws Exception {
+        List<String> argTypes = new ArrayList<>();
+        String opName = parseOperation(operation, argTypes);
+        // The order of properties in an object name is critical for Karaf, so we cannot use
+        // ObjectName.getCanonicalName() to get the object name string here
+        // See: https://issues.apache.org/jira/browse/KARAF-4600
+        Object[] params = new Object[] { objectName.toString(), opName, argTypes.toArray(new String[0]) };
+        String[] signature = new String[] { String.class.getName(), String.class.getName(), String[].class.getName() };
+        return (boolean) mBeanServer.invoke(securityMBean, "canInvoke", params, signature);
+    }
+
+    private String parseOperation(String operation, List<String> argTypes) {
+        operation = operation.trim();
+        int index = operation.indexOf('(');
+        if (index < 0) {
+            return operation;
+        }
+
+        String args = operation.substring(index + 1, operation.length() - 1);
+        for (String arg : args.split(",")) {
+            if (!"".equals(arg)) {
+                argTypes.add(arg);
+            }
+        }
+
+        return operation.substring(0, index);
+    }
+
+    private static void logMBeanError(Exception e) {
+        if (e instanceof InstanceNotFoundException) {
+            LOG.info("Instance not found: {}", e.getMessage());
+        } else if (e.getCause() instanceof InstanceNotFoundException) {
+            LOG.info("Instance not found: {}", e.getCause().getMessage());
+        } else {
+            LOG.error("Error while invoking JMXSecurity MBean: " + e.getMessage(), e);
+        }
+    }
+
+    protected Map<String, MBeanAttributeInfo> loadMBeanAttributes(ObjectName objectName) throws Exception {
+        MBeanInfo mBeanInfo = mBeanServer.getMBeanInfo(objectName);
+        Map<String, MBeanAttributeInfo> answer = new HashMap<>();
+        for (MBeanAttributeInfo info : mBeanInfo.getAttributes()) {
+            answer.put(info.getName(), info);
+        }
+        return answer;
+    }
+
+    public boolean canInvoke(ObjectName objectName, String operation) {
+        if (this.securityMBean == null) {
+            // JMXSecurity MBean is not found, thus RBAC is disabled
+            return true;
+        }
+
+        AccessControlContext acc = AccessController.getContext();
+        Subject subject = Subject.getSubject(acc);
+        try {
+            if (subject != null) {
+                String username = getUsernameFromSubject(subject);
+                return canInvokeCache.get(new CanInvokeKey(username, objectName, operation));
+            } else {
+                // For now, let's bypass the caching and directly invoke the security MBean if
+                // subject is not available (which could happen on some platforms other than Karaf)
+                LOG.debug("Subject not available, directly invoking canInvoke(): {}, {}", objectName, operation);
+                return doCanInvoke(objectName, operation);
+            }
+        } catch (Exception e) {
+            logMBeanError(e);
+            return false;
+        }
+    }
+
+    private static final List<String> KNOWN_PRINCIPALS = Arrays.asList(
+        "UserPrincipal", "KeycloakPrincipal", "JAASPrincipal", "SimplePrincipal");
+
+    private static String getUsernameFromSubject(Subject subject) {
+        Set<Principal> principals = subject.getPrincipals();
+
+        String username = null;
+
+        if (principals != null) {
+            for (Principal principal : principals) {
+                String principalClass = principal.getClass().getSimpleName();
+                if (KNOWN_PRINCIPALS.contains(principalClass)) {
+                    username = principal.getName();
+                    LOG.debug("Authorizing user {}", username);
+                }
+            }
+        }
+
+        return username;
+    }
+
+    public boolean isReadAllowed(ObjectName objectName, String attribute) {
+        if (this.securityMBean == null) {
+            // JMXSecurity MBean is not found, thus RBAC is disabled
+            return true;
+        }
+
+        try {
+            MBeanAttributeInfo info = mbeanInfoCache.get(objectName).get(attribute);
+            if (info == null) {
+                LOG.error("Attribute '{}' not found for MBean '{}'", attribute, objectName);
+                return false;
+            }
+            return canInvoke(objectName, getAccessor(info, false));
+        } catch (Exception e) {
+            logMBeanError(e);
+            return false;
+        }
+    }
+
+    public boolean isWriteAllowed(ObjectName objectName, String attribute) {
+        if (this.securityMBean == null) {
+            // JMXSecurity MBean is not found, thus RBAC is disabled
+            return true;
+        }
+
+        try {
+            MBeanAttributeInfo info = mbeanInfoCache.get(objectName).get(attribute);
+            if (info == null) {
+                LOG.error("Attribute '{}' not found for MBean '{}'", attribute, objectName);
+                return false;
+            }
+            return canInvoke(objectName, getAccessor(info, true));
+        } catch (Exception e) {
+            logMBeanError(e);
+            return false;
+        }
+    }
+
+    private String getAccessor(MBeanAttributeInfo attribute, boolean write) {
+        if (write) {
+            return String.format("set%s(%s)", attribute.getName(), attribute.getType());
+        } else {
+            return String.format("%s%s()", attribute.isIs() ? "is" : "get", attribute.getName());
+        }
+    }
+
+}

--- a/fabric/fabric-jolokia/src/main/java/io/fabric8/jolokia/RBACRestrictor.java
+++ b/fabric/fabric-jolokia/src/main/java/io/fabric8/jolokia/RBACRestrictor.java
@@ -15,6 +15,9 @@
  */
 package io.fabric8.jolokia;
 
+import java.io.IOException;
+import javax.management.ObjectName;
+
 import org.jolokia.config.ConfigKey;
 import org.jolokia.config.Configuration;
 import org.jolokia.restrictor.AllowAllRestrictor;
@@ -27,20 +30,6 @@ import org.jolokia.util.RequestType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.management.InstanceNotFoundException;
-import javax.management.MBeanAttributeInfo;
-import javax.management.MBeanException;
-import javax.management.MBeanInfo;
-import javax.management.MBeanServer;
-import javax.management.MalformedObjectNameException;
-import javax.management.ObjectName;
-import java.io.IOException;
-import java.lang.management.ManagementFactory;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
 /**
  * Ported from Hawtio.
  * <p>
@@ -52,8 +41,7 @@ public class RBACRestrictor implements Restrictor {
     private static final Logger LOG = LoggerFactory.getLogger(RBACRestrictor.class);
 
     protected Restrictor delegate;
-    protected MBeanServer mBeanServer;
-    protected ObjectName securityMBean;
+    protected RBACMBeanInvoker mBeanInvoker;
 
     public RBACRestrictor(Configuration config) {
         this(NetworkUtil.replaceExpression(config.get(ConfigKey.POLICY_LOCATION)));
@@ -61,7 +49,7 @@ public class RBACRestrictor implements Restrictor {
 
     public RBACRestrictor(String policyLocation) {
         initDelegate(policyLocation);
-        initSecurityMBean();
+        this.mBeanInvoker = new RBACMBeanInvoker();
     }
 
     protected void initDelegate(String policyLocation) {
@@ -80,116 +68,25 @@ public class RBACRestrictor implements Restrictor {
         }
     }
 
-    protected void initSecurityMBean() {
-        this.mBeanServer = ManagementFactory.getPlatformMBeanServer();
-        Set<ObjectName> mbeans = new HashSet<>();
-        try {
-            mbeans = mBeanServer.queryNames(new ObjectName("*:type=security,area=jmx,*"), null);
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Found JMXSecurity MBeans: {}", mbeans);
-            }
-        } catch (MalformedObjectNameException e) {
-            LOG.error(e.getMessage(), e);
-        }
-        if (mbeans.isEmpty()) {
-            LOG.info("Didn't discover any JMXSecurity MBeans, role based access control is disabled");
-            this.securityMBean = null;
-            return;
-        }
-
-        ObjectName chosen = null;
-        if (mbeans.size() == 1) {
-            chosen = mbeans.iterator().next();
-        } else if (mbeans.size() > 1) {
-            for (ObjectName mbean : mbeans) {
-                String name = mbean.toString();
-                if (!name.contains("HawtioDummy") && !name.contains("rank=")) {
-                    chosen = mbean;
-                    break;
-                }
-            }
-        }
-        LOG.info("Using MBean [{}] for role based access control", chosen);
-        this.securityMBean = chosen;
-    }
-
     @Override
     public boolean isOperationAllowed(ObjectName objectName, String operation) {
         boolean allowed = delegate.isOperationAllowed(objectName, operation);
         if (allowed) {
-            try {
-                allowed = canInvoke(objectName, operation);
-            } catch (Exception e) {
-                LOG.error("Error while invoking JMXSecurity MBean: " + e.getMessage(), e);
-                allowed = false;
-            }
+            allowed = mBeanInvoker.canInvoke(objectName, operation);
         }
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("isOperationAllowed(objectName = {}, operation = {}) = {}",
-                    objectName, operation, allowed);
-        }
+        LOG.debug("isOperationAllowed(objectName = {}, operation = {}) = {}",
+            new Object[] { objectName, operation, allowed });
         return allowed;
-    }
-
-    private boolean canInvoke(ObjectName objectName, String operation) throws Exception {
-        if (this.securityMBean == null) {
-            // JMXSecurity MBean is not found, thus RBAC is disabled
-            return true;
-        }
-        List<String> argTypes = new ArrayList<>();
-        String opName = parseOperation(operation, argTypes);
-        // The order of properties in an object name is critical for Karaf, so we cannot use
-        // ObjectName.getCanonicalName() to get the object name string here
-        // See: https://issues.apache.org/jira/browse/KARAF-4600
-        Object[] params = new Object[] { objectName.toString(), opName, argTypes.toArray(new String[0]) };
-        String[] signature = new String[] { String.class.getName(), String.class.getName(), String[].class.getName() };
-        try {
-            return (boolean) mBeanServer.invoke(securityMBean, "canInvoke", params, signature);
-        } catch (InstanceNotFoundException e) {
-            LOG.info("Instance not found: {}", e.getMessage());
-            return false;
-        } catch (MBeanException e) {
-            if (e.getCause() instanceof InstanceNotFoundException) {
-                LOG.info("Instance not found: {}", e.getCause().getMessage());
-                return false;
-            }
-            throw e;
-        }
-    }
-
-    private String parseOperation(String operation, List<String> argTypes) {
-        operation = operation.trim();
-        int index = operation.indexOf('(');
-        if (index < 0) {
-            return operation;
-        }
-
-        String args = operation.substring(index + 1, operation.length() - 1);
-        for (String arg : args.split(",")) {
-            if (!"".equals(arg)) {
-                argTypes.add(arg);
-            }
-        }
-
-        return operation.substring(0, index);
     }
 
     @Override
     public boolean isAttributeReadAllowed(ObjectName objectName, String attribute) {
         boolean allowed = delegate.isAttributeReadAllowed(objectName, attribute);
         if (allowed) {
-            try {
-                String accessor = resolveAccessor(objectName, attribute, false);
-                allowed = canInvoke(objectName, accessor);
-            } catch (Exception e) {
-                LOG.error("Error while invoking JMXSecurity MBean: " + e.getMessage(), e);
-                allowed = false;
-            }
+            allowed = mBeanInvoker.isReadAllowed(objectName, attribute);
         }
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("isAttributeReadAllowed(objectName = {}, attribute = {}) = {}",
-                    objectName, attribute, allowed);
-        }
+        LOG.debug("isAttributeReadAllowed(objectName = {}, attribute = {}) = {}",
+            new Object[] { objectName, attribute, allowed });
         return allowed;
     }
 
@@ -197,75 +94,40 @@ public class RBACRestrictor implements Restrictor {
     public boolean isAttributeWriteAllowed(ObjectName objectName, String attribute) {
         boolean allowed = delegate.isAttributeWriteAllowed(objectName, attribute);
         if (allowed) {
-            try {
-                String accessor = resolveAccessor(objectName, attribute, true);
-                allowed = canInvoke(objectName, accessor);
-            } catch (Exception e) {
-                LOG.error("Error while invoking JMXSecurity MBean: " + e.getMessage(), e);
-                allowed = false;
-            }
+            allowed = mBeanInvoker.isWriteAllowed(objectName, attribute);
         }
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("isAttributeWriteAllowed(objectName = {}, attribute = {}) = {}",
-                    objectName, attribute, allowed);
-        }
+        LOG.debug("isAttributeWriteAllowed(objectName = {}, attribute = {}) = {}",
+            new Object[] { objectName, attribute, allowed });
         return allowed;
-    }
-
-    private String resolveAccessor(ObjectName objectName, String attribute, boolean write) throws Exception {
-        MBeanInfo mBeanInfo = mBeanServer.getMBeanInfo(objectName);
-        MBeanAttributeInfo attributeInfo = null;
-        for (MBeanAttributeInfo info : mBeanInfo.getAttributes()) {
-            if (info.getName().equals(attribute)) {
-                attributeInfo = info;
-                break;
-            }
-        }
-        if (attributeInfo == null) {
-            throw new IllegalArgumentException("Attribute '" + attribute + "' not found for MBean '" + objectName + "'");
-        }
-        if (write) {
-            return String.format("set%s(%s)", attribute, attributeInfo.getType());
-        } else {
-            return String.format("%s%s()", attributeInfo.isIs() ? "is" : "get", attribute);
-        }
     }
 
     @Override
     public boolean isHttpMethodAllowed(HttpMethod method) {
         boolean allowed = delegate.isHttpMethodAllowed(method);
-        if (LOG.isTraceEnabled()) {
-            LOG.trace("isHttpMethodAllowed(method = {}) = {}", method, allowed);
-        }
+        LOG.trace("isHttpMethodAllowed(method = {}) = {}", method, allowed);
         return allowed;
     }
 
     @Override
     public boolean isTypeAllowed(RequestType type) {
         boolean allowed = delegate.isTypeAllowed(type);
-        if (LOG.isTraceEnabled()) {
-            LOG.trace("isTypeAllowed(type = {}) = {}", type, allowed);
-        }
+        LOG.trace("isTypeAllowed(type = {}) = {}", type, allowed);
         return allowed;
     }
 
     @Override
     public boolean isRemoteAccessAllowed(String... hostOrAddress) {
         boolean allowed = delegate.isRemoteAccessAllowed(hostOrAddress);
-        if (LOG.isTraceEnabled()) {
-            LOG.trace("isRemoteAccessAllowed(hostOrAddress = {}) = {}",
-                    hostOrAddress, allowed);
-        }
+        LOG.trace("isRemoteAccessAllowed(hostOrAddress = {}) = {}",
+            hostOrAddress, allowed);
         return allowed;
     }
 
     @Override
     public boolean isOriginAllowed(String origin, boolean strictCheck) {
         boolean allowed = delegate.isOriginAllowed(origin, strictCheck);
-        if (LOG.isTraceEnabled()) {
-            LOG.trace("isOriginAllowed(origin = {}, strictCheck = {}) = {}",
-                    origin, strictCheck, allowed);
-        }
+        LOG.trace("isOriginAllowed(origin = {}, strictCheck = {}) = {}",
+            new Object[] { origin, strictCheck, allowed });
         return allowed;
     }
 

--- a/fabric/fabric-jolokia/src/test/java/io/fabric8/jolokia/RBACRestrictorTest.java
+++ b/fabric/fabric-jolokia/src/test/java/io/fabric8/jolokia/RBACRestrictorTest.java
@@ -78,6 +78,7 @@ public class RBACRestrictorTest {
         assertThat(restrictor.isAttributeReadAllowed(new ObjectName("java.lang:type=Memory"), "Verbose"), is(true));
         assertThat(restrictor.isAttributeReadAllowed(new ObjectName("java.lang:type=Runtime"), "VmVersion"), is(false));
         assertThat(restrictor.isAttributeReadAllowed(new ObjectName("java.lang:type=Runtime"), "xxx"), is(false));
+        assertThat(restrictor.isAttributeReadAllowed(new ObjectName("fabric:type=NoSuchType"), "Whatever"), is(false));
     }
 
     @Test
@@ -86,6 +87,7 @@ public class RBACRestrictorTest {
         assertThat(restrictor.isAttributeWriteAllowed(new ObjectName("java.lang:type=Memory"), "Verbose"), is(true));
         assertThat(restrictor.isAttributeWriteAllowed(new ObjectName("java.lang:type=Runtime"), "VmVersion"), is(false));
         assertThat(restrictor.isAttributeWriteAllowed(new ObjectName("java.lang:type=Runtime"), "xxx"), is(false));
+        assertThat(restrictor.isAttributeWriteAllowed(new ObjectName("fabric:type=NoSuchType"), "Whatever"), is(false));
     }
 
     public interface JMXSecurityMBean {


### PR DESCRIPTION
https://issues.jboss.org/browse/PATCH-2606