### PR TITLE
ENTESB-8534 Use the version of jolokia-core that is specified in the fabric8 pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1558,6 +1558,7 @@
                                   <include>org.apache.httpcomponents:*</include>
                                   <include>org.slf4j:*</include>
 
+                                  <include>org.jolokia:jolokia-core</include>
                                   <include>org.hibernate:hibernate-validator</include>
                                   <include>io.swagger:*</include>
                                   <include>io.undertow:*</include>
@@ -1622,7 +1623,6 @@
                                           <include>mysql:*</include>
                                           <include>org.apache.tomcat*:*</include>
                                           <include>org.eclipse.jetty*:*</include>
-                                          <include>org.jolokia:jolokia-core</include>
                                           <include>org.jboss:jboss-transaction-spi</include>
                                           <include>org.jboss.logging:jboss-logging</include>
 


### PR DESCRIPTION
Use the version of jolokia-core that is specified in the fabric8 pom.xml rather than the one that is coming from org.springframework.boot:spring-boot-dependencies