### PR TITLE
ENTESB-8534 Use the version of jolokia-core that is specified in the fabric8 pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1557,6 +1557,7 @@
                                   <include>org.apache.httpcomponents:*</include>
                                   <include>org.slf4j:*</include>
 
+                                  <include>org.jolokia:jolokia-core</include>
                                   <include>org.hibernate:hibernate-validator</include>
                                   <include>io.swagger:*</include>
                                   <include>io.undertow:*</include>
@@ -1617,7 +1618,6 @@
                                           <include>mysql:*</include>
                                           <include>org.apache.tomcat*:*</include>
                                           <include>org.eclipse.jetty*:*</include>
-                                          <include>org.jolokia:jolokia-core</include>
                                           <include>org.jboss:jboss-transaction-spi</include>
                                           <include>org.jboss.logging:jboss-logging</include>
                                           <include>org.jboss.narayana.jta:*</include>


### PR DESCRIPTION
Cherry pick over the change from 7.0.1 to 7.1 that uses the jolokia version from fabric8 pom.xml rather than from the spring-boot-dependencies bom.