### PR TITLE
PATCH-2738: ENTESB-9451: fixed Fabric8 gateway does not close client connections …

### DIFF
--- a/gateway/gateway-core/src/test/java/io/fabric8/gateway/HttpGatewayRequestTimeoutTest.java
+++ b/gateway/gateway-core/src/test/java/io/fabric8/gateway/HttpGatewayRequestTimeoutTest.java
@@ -132,7 +132,7 @@ public class HttpGatewayRequestTimeoutTest extends AbstractHttpGatewayTest {
 
         HttpClientResponse response = future.await();
 
-        assertEquals( response.statusCode(), 504 );
+        assertEquals( 504, response.statusCode() );
 
         stopHttpGateway();
         stopVertx();


### PR DESCRIPTION
…even when the target container has crashed

Actually clients would hang in case of any exception different from java.util.concurrent.TimeoutException and io.netty.channel.ConnectTimeoutException.