### PR TITLE
ENTESB-9638 Upgrade activemq-client to 630347

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
     <properties>
 
         <!-- upstream vs redhat versions of dependencies goes here -->
-        <activemq.version>5.11.0.redhat-630343</activemq.version>
+        <activemq.version>5.11.0.redhat-630347</activemq.version>
         <arquillian-cube.version>1.9.0</arquillian-cube.version>
         <camel.version>2.19.1</camel.version>
         <cxf.version>3.1.11.fuse-710001</cxf.version>


### PR DESCRIPTION
This upgrades the activemq-client to the version shipped in 7.1