### PR TITLE
[ENTESB-9895] Upgrade javax.servlet.jsp.jstl to fix CVE

### DIFF
--- a/components/rest-utils/pom.xml
+++ b/components/rest-utils/pom.xml
@@ -121,7 +121,16 @@
           <groupId>org.glassfish</groupId>
           <artifactId>javax.el</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.glassfish.web</groupId>
+          <artifactId>javax.servlet.jsp.jstl</artifactId>
+        </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.web</groupId>
+      <artifactId>javax.servlet.jsp.jstl</artifactId>
+      <version>1.2.3</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
https://issues.jboss.org/browse/ENTESB-9895

As a side note: I'm not sure if rest-utils is still in use somewhere