### PR TITLE
ENTESB-10123 Add back wildcard for fuse-karaf features

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1593,6 +1593,8 @@
                                   <!-- The kubernetes Client and Model -->
                                   <include>io.fabric8:openshift-*</include>
                                   <include>io.fabric8.kubernetes:*</include>
+                                  <include>io.fabric8:fabric8-karaf*</include>
+                                  <include>io.fabric8:kubernetes-*</include>
 
                                   <include>org.fusesource:camel-sap</include>
                                   <include>org.fusesource:camel-activemq</include>
@@ -1625,7 +1627,6 @@
                                       <excludes>
                                           <exclude>javax.ws.rs:javax.ws.rs-api</exclude>
                                           <exclude>org.fusesource:camel-activemq</exclude>
-                                          <exclude>org.jboss.fuse:fuse-karaf-framework</exclude>
                                           <exclude>javax.annotation:jsr250-api</exclude>
                                           <exclude>xml-apis:xml-apis:1.4.01</exclude>
 


### PR DESCRIPTION
The build is failing (https://fusesource-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/fuse-7.3-release-pipeline/148/) here -

[ERROR]   The project io.fabric8.quickstarts:karaf-camel-amq:1.0-SNAPSHOT (/home/jenkins/karaf-camel-amq/pom.xml) has 1 error
[ERROR]     'dependencies.dependency.version' for io.fabric8:fabric8-karaf-features:xml:features is missing. @ line 77, column 17

In trying to take out duplicate entries, it was inadvertantly removed from bom-fuse-karaf.     Adding it back.