### PR TITLE
[ENTESB-10385] Openshift 4 + FMP: DefaultKubernetesClient cannot be cast to OpenShiftClient

### DIFF
--- a/components/kubernetes-api/src/main/java/io/fabric8/kubernetes/api/KubernetesHelper.java
+++ b/components/kubernetes-api/src/main/java/io/fabric8/kubernetes/api/KubernetesHelper.java
@@ -2193,7 +2193,8 @@ public final class KubernetesHelper {
                 List<String> paths = rootPaths.getPaths();
                 if (paths != null) {
                     for (String path : paths) {
-                        if (java.util.Objects.equals("/oapi", path) || java.util.Objects.equals("oapi", path)) {
+                        if (java.util.Objects.equals("/oapi", path) || java.util.Objects.equals("oapi", path)
+                                || "/apis/machine.openshift.io".equals(path)) {
                             IS_OPENSHIFT.putIfAbsent(masterUrl, true);
                             return true;
                         }


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/ENTESB-10385

OpenShift 4 no longer provides _/oapi_ among its services.