### PR TITLE
Simplify fabric8 for spring-boot2

### DIFF
--- a/components/pom.xml
+++ b/components/pom.xml
@@ -72,9 +72,6 @@
     <module>fabric8-selenium</module>
     <module>fabric8-spring-boot</module>
 
-    <!-- karaf support -->
-    <module>fabric8-karaf</module>
-
     <!-- swagger -->
     <module>swagger-annotator</module>
     <module>swagger-model</module>

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -62,15 +62,11 @@
     <module>fabric8-apm</module>
     <module>fabric8-arquillian</module>
     <module>fabric8-cxf</module>
-    <!--<module>fabric8-cxf-plugins</module>--> <!-- TODO: does not work yet -->
-    <!--<module>fabric8-cxf-registry</module>--> <!-- TODO: does not work yet -->
     <module>fabric8-devops</module>
     <module>fabric8-devops-connector</module>
     <module>fabric8-jgroups</module>
     <module>fabric8-profiles</module>
     <module>fabric8-project-utils</module>
-    <module>fabric8-selenium</module>
-    <module>fabric8-spring-boot</module>
 
     <!-- swagger -->
     <module>swagger-annotator</module>

--- a/pom.xml
+++ b/pom.xml
@@ -81,9 +81,9 @@
         <!-- upstream vs redhat versions of dependencies goes here -->
         <activemq.version>5.11.0.redhat-630396</activemq.version>
         <arquillian-cube.version>1.9.0</arquillian-cube.version>
-        <camel.version>2.23.2.fuse-740002</camel.version>
-        <cxf.version>3.2.7.fuse-sb2-740008</cxf.version>
-        <cxf.plugin.version>3.2.7.fuse-740004</cxf.plugin.version>
+        <camel.version>2.23.2.fuse-750019</camel.version>
+        <cxf.version>3.2.7.fuse-sb2-750015</cxf.version>
+        <cxf.plugin.version>3.2.7.fuse-sb2-750015</cxf.plugin.version>
 
         <commons.collections.version>3.2.2.redhat-2</commons.collections.version>
         <version.fuse-karaf>7.4.0.fuse-740015</version.fuse-karaf>
@@ -98,7 +98,7 @@
         <swagger.jaxrs.version>1.5.18.fuse70-1-redhat-1</swagger.jaxrs.version>
         <vertx.version>3.5.0</vertx.version>
         <weld.version>2.3.5.Final</weld.version>
-        <version.org.fusesource.camel-sap>7.4.0.fuse-sb2-740002</version.org.fusesource.camel-sap>
+        <version.org.fusesource.camel-sap>7.5.0.fuse-sb2-750018</version.org.fusesource.camel-sap>
         <version.org.fusesource.camel-activemq>${version.org.fusesource.camel-sap}</version.org.fusesource.camel-activemq>
         <version.io.undertow>2.0.23.Final</version.io.undertow>
 
@@ -145,7 +145,7 @@
         <jetty.version>9.4.12.v20180830</jetty.version>
 
 	<rhoar.version>2.1.3.Final</rhoar.version>
-        <narayana-spring-boot.version>2.1.1.fuse-sb2-740002</narayana-spring-boot.version>
+        <narayana-spring-boot.version>2.1.1.fuse-sb2-750016</narayana-spring-boot.version>
         <narayana.version>5.9.1.Final-redhat-00001</narayana.version>
 
 <!--
@@ -162,7 +162,7 @@
         <maven-plugin-plugin.version>3.4</maven-plugin-plugin.version>
         <maven.failsafe.plugin.version>2.19</maven.failsafe.plugin.version>
         <maven.javadoc.plugin.version>2.10.3</maven.javadoc.plugin.version>
-        <mockwebserver.version>0.0.12</mockwebserver.version>
+        <mockwebserver.version>0.0.17</mockwebserver.version>
         <mvel.version>2.4.0.Final</mvel.version>
         <osgi.version>4.3.1</osgi.version>
         <osgi-compendium.version>4.3.1</osgi-compendium.version>
@@ -180,7 +180,6 @@
         <spring.version>4.3.20.RELEASE</spring.version>
         <spring.boot.version>1.5.17.RELEASE</spring.boot.version>
         <spring-cloud-kubernetes.version>0.1.6.fuse-740009</spring-cloud-kubernetes.version>
-        <sundrio.plugin.version>0.16.5</sundrio.plugin.version>
         <tomcat-embed.version>8.0.36.redhat-35</tomcat-embed.version>
         <validation-api.version>1.1.0.Final-redhat-1</validation-api.version>
         <zookeeper.version>3.4.9</zookeeper.version>
@@ -1119,9 +1118,11 @@
     <modules>
         <module>parent</module>
         <module>components</module>
+<!-- 
         <module>fabric8-apt</module>
         <module>hawt-app-maven-plugin</module>
         <module>tooling</module>
+-->
     </modules>
 
     <build>
@@ -1175,466 +1176,6 @@
                               </condition>
                           </target>
                       </configuration>
-                  </execution>
-              </executions>
-          </plugin>
-          <plugin>
-              <groupId>io.sundr</groupId>
-              <artifactId>sundr-maven-plugin</artifactId>
-              <version>${sundrio.plugin.version}</version>
-              <configuration>
-                  <bomTemplateUrl>file:${urlSlashesOsModifier}${project.basedir}/custom-bom.xml.vm</bomTemplateUrl>
-                  <boms>
-                      <bom>
-                          <artifactId>fabric8-project-bom</artifactId>
-                          <name>Fabric8 :: Project :: Bom</name>
-                          <dependencies>
-                              <includes>
-                                  <include>io.fabric8:kubernetes-*</include>
-                                  <include>io.fabric8:openshift-*</include>
-                              </includes>
-                          </dependencies>
-                          <plugins>
-                              <includes>
-                                  <include>io.fabric8:*</include>
-                              </includes>
-                          </plugins>
-                          <properties>
-                              <skipStagingRepositoryClose>true</skipStagingRepositoryClose>
-                          </properties>
-                          <inheritPluginManagement>true</inheritPluginManagement>
-                      </bom>
-                      <bom>
-                          <artifactId>fabric8-project-bom-with-platform-deps</artifactId>
-                          <name>Fabric8 :: Project :: Bom with Platform Dependencies</name>
-                          <dependencies>
-                              <includes>
-                                  <!-- The kubernetes Client and Model -->
-                                  <include>io.fabric8:kubernetes-*</include>
-                                  <include>io.fabric8:openshift-*</include>
-
-                                  <include>javax*:*</include>
-                                  <!-- Core platform -->
-                                  <include>org.jboss.weld*:*</include>
-                                  <include>org.jboss.arquillian*:*</include>
-                                  <include>org.jboss.shrinkwrap*:*</include>
-                                  <include>org.apache.deltaspike*:*</include>
-                                  <!-- minor things that are easy to get wrong -->
-                                  <include>org.ops4j.pax.url:pax-url-aether</include>
-                                  <include>org.codehaus.plexus:plexus-utils</include>
-                                  <include>xml-apis:xml-apis</include>
-                              </includes>
-                          </dependencies>
-                          <plugins>
-                              <includes>
-                                  <include>io.fabric8:*</include>
-                              </includes>
-                          </plugins>
-                          <properties>
-                              <skipStagingRepositoryClose>true</skipStagingRepositoryClose>
-                          </properties>
-                          <inheritDependencyManagement>true</inheritDependencyManagement>
-                          <inheritPluginManagement>true</inheritPluginManagement>
-                      </bom>
-                      <bom>
-                          <artifactId>fabric8-project-bom-camel-spring-boot</artifactId>
-                          <name>Fabric8 :: Project :: Bom for Camel and Spring-Boot</name>
-                          <extraDependencies>
-                              <dependency>
-                                  <groupId>org.apache.qpid</groupId>
-                                  <artifactId>qpid-jms-client</artifactId>
-                                  <version>${qpid-jms-client.version}</version>
-                              </dependency>
-                              <dependency>
-                                  <groupId>org.apache.qpid</groupId>
-                                  <artifactId>proton-j</artifactId>
-                                  <version>${qpid-proton-j.version}</version>
-                              </dependency>
-                              <dependency>
-                                  <groupId>javax.el</groupId>
-                                  <artifactId>javax.el-api</artifactId>
-                                  <version>${javax.el-api.version}</version>
-                              </dependency>
-                              <dependency>
-                                  <groupId>org.hibernate</groupId>
-                                  <artifactId>hibernate-core</artifactId>
-                                  <version>${hibernate-core.version}</version>
-                              </dependency>
-                          </extraDependencies>
-                          <dependencies>
-                              <includes>
-                                  <!-- The kubernetes Client and Model -->
-                                  <include>io.fabric8:openshift-*</include>
-                                  <include>io.fabric8:kubernetes-client</include>
-
-                                  <include>javax*:*</include>
-
-                                  <include>org.jboss.arquillian*:*</include>
-                                  <include>org.jboss.shrinkwrap*:*</include>
-                                  <include>org.assertj*:*</include>
-
-                                  <include>me.snowdrop:*</include>
-
-                                  <include>xml-apis:xml-apis</include>
-                                  <include>org.fusesource:camel-activemq</include>
-                                  <include>org.fusesource:camel-sap</include>
-                                  <include>org.fusesource:camel-sap-starter</include>
-
-                                  <include>org.apache.cxf:cxf-spring-boot-starter-jaxrs</include>
-                                  <include>org.apache.cxf:cxf-spring-boot-starter-jaxws</include>
-                                  <include>org.apache.cxf:cxf-rt-rs-service-description-swagger</include>
-                                  <include>org.apache.cxf:cxf-rt-rs-service-description-openapi-v3</include>
-                                  <include>org.apache.httpcomponents:*</include>
-                                  <include>org.slf4j:*</include>
-
-                                  <include>org.jolokia:jolokia-core</include>
-                                  <include>org.hibernate:hibernate-validator</include>
-                                  <include>org.hibernate:hibernate-entitymanager</include>
-                                  <include>org.hibernate:hibernate-core</include>
-                                  <include>io.swagger:*</include>
-                                  <include>io.undertow:*</include>
-                                  <include>junit:junit</include>
-                              </includes>
-                              <excludes>
-                                  <exclude>org.optaplanner:*</exclude>
-                                  <exclude>javax.servlet:javax.servlet-api</exclude>
-                                  <exclude>javax.servlet:servlet-api</exclude>
-                                  <exclude>javax.activation:activation:1.1</exclude>
-                                  <exclude>org.apache.httpcomponents:httpasyncclient</exclude>
-                                  <exclude>org.apache.httpcomponents:httpclient</exclude>
-                                  <exclude>org.apache.httpcomponents:httpclient-cache</exclude>
-                                  <exclude>org.apache.httpcomponents:httpclient-osgi</exclude>
-                                  <exclude>org.apache.httpcomponents:httpcore</exclude>
-                                  <exclude>org.apache.httpcomponents:httpmime</exclude>
-                                  <exclude>javax.validation:validation-api</exclude>
-                                  <exclude>org.apache.cxf:cxf-rt-rs-service-description-swagger</exclude>
-                              </excludes>
-                          </dependencies>
-                          <imports>
-                              <import>
-                                  <groupId>me.snowdrop</groupId>
-                                  <artifactId>spring-boot-bom</artifactId>
-                                  <version>${rhoar.version}</version>
-                                  <dependencyManagement>
-                                      <includes>
-                                          <!-- These are artifacts that are excluded from camel, and we expect the versions from
-                                               spring-boot-dependencies -->
-                                          <include>de.flapdoodle*:*</include>
-                                          <include>org.apache.activemq:*</include>
-                                          <include>org.apache.commons:commons-pool2</include>
-
-                                          <include>org.apache.httpcomponents:httpasyncclient</include>
-                                          <include>org.apache.httpcomponents:httpclient</include>
-                                          <include>org.apache.httpcomponents:httpclient-cache</include>
-                                          <include>org.apache.httpcomponents:httpclient-osgi</include>
-                                          <include>org.apache.httpcomponents:httpcore</include>
-                                          <include>org.apache.httpcomponents:httpmime</include>
-
-                                          <include>org.apache.derby:derby</include>
-                                          <include>org.apache.logging.log4j:*</include>
-
-                                          <include>org.codehaus.groovy:*</include>
-                                          <include>org.hsqldb:*</include>
-                                          <include>org.mockito:*</include>
-
-                                          <include>org.springframework*:*</include>
-
-                                          <include>commons-codec:*</include>
-                                          <include>commons-collections:*</include>
-                                          <include>commons-dbcp:*</include>
-                                          <include>org.apache.commons:commons-dbcp2</include>
-                                          <include>commons-pool:*</include>
-
-                                          <include>com.github.ben-manes.caffeine:caffeine</include>
-                                          <include>com.datastax.cassandra:*</include>
-
-                                          <include>com.fasterxml.jackson.*:*</include>
-
-                                          <include>com.google.code.gson:*</include>
-                                          <include>javax.servlet:javax.servlet-api</include>
-                                          <include>junit:*</include>
-                                          <include>net.sf.ehcache:ehcache</include>
-
-                                          <!-- Others that we need -->
-                                          <include>mysql:*</include>
-                                          <include>org.apache.tomcat*:*</include>
-                                          <include>org.postgresql:*</include>
-                                          <include>org.eclipse.jetty*:*</include>
-                                          <include>org.jboss:jboss-transaction-spi</include>
-                                          <include>org.jboss.logging:jboss-logging</include>
-
-                                          <include>org.springframework.boot:spring-boot-starter</include>
-                                          <include>org.springframework.boot:spring-boot-starter-activemq</include>
-                                          <include>org.springframework.boot:spring-boot-starter-actuator</include>
-                                          <include>org.springframework.boot:spring-boot-starter-jdbc</include>
-                                          <include>org.springframework.boot:spring-boot-starter-data-jpa</include>
-                                          <include>org.springframework.boot:spring-boot-starter-logging</include>
-                                          <include>org.springframework.boot:spring-boot-starter-security</include>
-                                          <include>org.springframework.boot:spring-boot-starter-test</include>
-                                          <include>org.springframework.boot:spring-boot-starter-tomcat</include>
-                                          <include>org.springframework.boot:spring-boot-starter-web</include>
-                                          <include>org.springframework.boot:spring-boot-starter-undertow</include>
-                                          <include>org.springframework.boot:spring-boot-configuration-processor</include>
-                                          <include>org.springframework.boot:spring-boot-maven-plugin</include>
-                                      </includes>
-                                      <excludes>
-                                          <exclude>org.apache.activemq:activemq-camel</exclude>
-                                          <exclude>org.assertj*:*</exclude>
-                                          <exclude>org.slf4j:*</exclude>
-                                          <exclude>junit:junit</exclude>
-
-                                          <!-- Out of scope sb starters -->
-                                          <exclude>org.springframework.boot:spring-boot-starter-aop</exclude>
-                                          <exclude>org.springframework.boot:spring-boot-starter-artemis</exclude>
-                                          <exclude>org.springframework.boot:spring-boot-starter-batch</exclude>
-                                          <exclude>org.springframework.boot:spring-boot-starter-cloud-connectors</exclude>
-                                          <exclude>org.springframework.boot:spring-boot-starter-data-cassandra</exclude>
-                                          <exclude>org.springframework.boot:spring-boot-starter-data-couchbase</exclude>
-                                          <exclude>org.springframework.boot:spring-boot-starter-data-elasticsearch</exclude>
-                                          <exclude>org.springframework.boot:spring-boot-starter-data-ldap</exclude>
-                                          <exclude>org.springframework.boot:spring-boot-starter-data-mongodb</exclude>
-                                          <exclude>org.springframework.boot:spring-boot-starter-data-neo4j</exclude>
-                                          <exclude>org.springframework.boot:spring-boot-starter-data-redis</exclude>
-                                          <exclude>org.springframework.boot:spring-boot-starter-data-redis-reactive</exclude>
-                                          <exclude>org.springframework.boot:spring-boot-starter-data-rest</exclude>
-                                          <exclude>org.springframework.boot:spring-boot-starter-data-solr</exclude>
-                                          <exclude>org.springframework.boot:spring-boot-starter-freemarker</exclude>
-                                          <exclude>org.springframework.boot:spring-boot-starter-groovy-templates</exclude>
-                                          <exclude>org.springframework.boot:spring-boot-starter-hateoas</exclude>
-                                          <exclude>org.springframework.boot:spring-boot-starter-integration</exclude>
-                                          <exclude>org.springframework.boot:spring-boot-starter-jersey</exclude>
-                                          <exclude>org.springframework.boot:spring-boot-starter-jetty</exclude>
-                                          <exclude>org.springframework.boot:spring-boot-starter-jooq</exclude>
-                                          <exclude>org.springframework.boot:spring-boot-starter-jta-atomikos</exclude>
-                                          <exclude>org.springframework.boot:spring-boot-starter-jta-bitronix</exclude>
-                                          <exclude>org.springframework.boot:spring-boot-starter-log4j2</exclude>
-                                          <exclude>org.springframework.boot:spring-boot-starter-mail</exclude>
-                                          <exclude>org.springframework.boot:spring-boot-starter-mobile</exclude>
-                                          <exclude>org.springframework.boot:spring-boot-starter-mustache</exclude>
-                                          <exclude>org.springframework.boot:spring-boot-starter-reactor-netty</exclude>
-                                          <exclude>org.springframework.boot:spring-boot-starter-redis</exclude>
-                                          <exclude>org.springframework.boot:spring-boot-starter-remote-shell</exclude>
-                                          <exclude>org.springframework.boot:spring-boot-starter-social-facebook</exclude>
-                                          <exclude>org.springframework.boot:spring-boot-starter-social-linkedin</exclude>
-                                          <exclude>org.springframework.boot:spring-boot-starter-social-twitter</exclude>
-                                          <exclude>org.springframework.boot:spring-boot-starter-thymeleaf</exclude>
-                                          <exclude>org.springframework.boot:spring-boot-starter-validation</exclude>
-                                          <exclude>org.springframework.boot:spring-boot-starter-velocity</exclude>
-                                          <exclude>org.springframework.boot:spring-boot-starter-web-services</exclude>
-                                          <exclude>org.springframework.boot:spring-boot-starter-webflux</exclude>
-                                          <exclude>org.springframework.boot:spring-boot-starter-websocket</exclude>
-                                          <exclude>org.springframework.boot:spring-boot-starter-ws</exclude>
-                                      </excludes>
-                                  </dependencyManagement>
-                              </import>
-                              <import>
-                                  <groupId>org.apache.camel</groupId>
-                                  <artifactId>camel-spring-boot-dependencies</artifactId>
-                                  <version>${camel.version}</version>
-                                  <dependencyManagement>
-                                      <includes>
-                                          <include>*:*</include>
-                                      </includes>
-                                      <excludes>
-                                          <exclude>javax.annotation:jsr250-ap</exclude>
-                                          <exclude>io.fabric8*:*</exclude>
-                                          <exclude>org.slf4j:*</exclude>
-                                          <exclude>junit:junit</exclude>
-                                          <exclude>javax.annotation:jsr250-api</exclude>
-                                          <exclude>org.springframework.boot:spring-boot</exclude>
-                                          <exclude>org.springframework.boot:spring-boot-test</exclude>
-
-                                          <exclude>org.apache.httpcomponents:httpasyncclient</exclude>
-                                          <exclude>org.apache.httpcomponents:httpclient</exclude>
-                                          <exclude>org.apache.httpcomponents:httpclient-cache</exclude>
-                                          <exclude>org.apache.httpcomponents:httpclient-osgi</exclude>
-                                          <exclude>org.apache.httpcomponents:httpcore</exclude>
-                                          <exclude>org.apache.httpcomponents:httpmime</exclude>
-
-
-                                          <!-- Exclude community docs -->
-                                          <exclude>org.apache.camel:camel-manual</exclude>
-
-                                          <!-- Deprecated components -->
-                                          <exclude>org.apache.camel:camel-context</exclude>
-                                          <exclude>org.apache.camel:camel-context-starter</exclude>
-                                          <exclude>org.apache.camel:camel-cache</exclude>
-                                          <exclude>org.apache.camel:camel-cache-starter</exclude>
-                                          <exclude>org.apache.camel:camel-elasticsearch5</exclude>
-                                          <exclude>org.apache.camel:camel-elasticsearch5-starter</exclude>
-                                          <exclude>org.apache.camel:camel-hdfs</exclude>
-                                          <exclude>org.apache.camel:camel-hdfs-starter</exclude>
-                                          <exclude>org.apache.camel:camel-http</exclude>
-                                          <exclude>org.apache.camel:camel-ibatis</exclude>
-                                          <exclude>org.apache.camel:camel-ignite</exclude>
-                                          <exclude>org.apache.camel:camel-ignite-starter</exclude>
-                                          <exclude>org.apache.camel:camel-ironmq</exclude>
-                                          <exclude>org.apache.camel:camel-ironmq-starter</exclude>
-                                          <exclude>org.apache.camel:camel-javaspace</exclude>
-                                          <exclude>org.apache.camel:camel-javaspace-starter</exclude>
-                                          <exclude>org.apache.camel:camel-kestrel</exclude>
-                                          <exclude>org.apache.camel:camel-kestrel-starter</exclude>
-                                          <exclude>org.apache.camel:camel-krati</exclude>
-                                          <exclude>org.apache.camel:camel-krati-starter</exclude>
-                                          <exclude>org.apache.camel:camel-mina</exclude>
-                                          <exclude>org.apache.camel:camel-netty</exclude>
-                                          <exclude>org.apache.camel:camel-netty-starter</exclude>
-                                          <exclude>org.apache.camel:camel-netty-http</exclude>
-                                          <exclude>org.apache.camel:camel-netty-http-starter</exclude>
-                                          <exclude>org.apache.camel:camel-openshift</exclude>
-                                          <exclude>org.apache.camel:camel-openshift-starter</exclude>
-                                          <exclude>org.apache.camel:camel-quartz</exclude>
-                                          <exclude>org.apache.camel:camel-routebox</exclude>
-                                          <exclude>org.apache.camel:camel-routebox-starter</exclude>
-                                          <exclude>org.apache.camel:camel-swagger</exclude>
-
-                                          <exclude>org.apache.camel:camel-xmlrpc</exclude>
-                                          <exclude>org.apache.camel:camel-xmlrpc-starter</exclude>
-
-                                      </excludes>
-                                  </dependencyManagement>
-                              </import>
-                              <import>
-                                  <groupId>org.arquillian.cube</groupId>
-                                  <artifactId>arquillian-cube-bom</artifactId>
-                                  <version>${arquillian-cube.version}</version>
-                                  <dependencyManagement>
-                                      <includes>
-                                          <include>org.arquillian.cube:*</include>
-                                      </includes>
-                                  </dependencyManagement>
-                              </import>
-                              <import>
-                                  <groupId>io.fabric8</groupId>
-                                  <artifactId>spring-cloud-kubernetes-bom-with-platform-deps</artifactId>
-                                  <version>${spring-cloud-kubernetes.version}</version>
-                                  <dependencyManagement>
-                                      <includes>
-                                          <include>*:*</include>
-                                      </includes>
-                                      <excludes>
-                                          <exclude>org.apache.httpcomponents:httpasyncclient</exclude>
-                                          <exclude>org.apache.httpcomponents:httpclient</exclude>
-                                          <exclude>org.apache.httpcomponents:httpclient-cache</exclude>
-                                          <exclude>org.apache.httpcomponents:httpclient-osgi</exclude>
-                                          <exclude>org.apache.httpcomponents:httpcore</exclude>
-                                          <exclude>org.apache.httpcomponents:httpmime</exclude>
-
-                                          <exclude>org.springframework.boot:spring-boot</exclude>
-                                          <exclude>org.springframework.boot:spring-boot-test</exclude>
-                                          <exclude>javax.inject:javax.inject</exclude>
-                                          <exclude>commons-io:commons-io</exclude>
-                                          <exclude>junit:junit</exclude>
-                                          <exclude>org.slf4j:*</exclude>
-                                          <exclude>org.springframework:*</exclude>
-                                          <exclude>org.springframework.boot:*</exclude>
-                                          <exclude>commons-lang:commons-lang</exclude>
-                                          <exclude>io.fabric8:kubernetes-*</exclude>
-                                          <exclude>io.fabric8:openshift-*</exclude>
-                                          <exclude>com.squareup.okhttp:*</exclude>
-                                          <exclude>com.squareup.okio:*</exclude>
-                                          <exclude>io.zipkin.java:*</exclude>
-                                          <exclude>org.optaplanner:*</exclude>
-                                      </excludes>
-                                  </dependencyManagement>
-                              </import>
-                              <import>
-                                  <groupId>me.snowdrop</groupId>
-                                  <artifactId>narayana-spring-boot-core</artifactId>
-                                  <version>${narayana-spring-boot.version}</version>
-                                  <dependencyManagement>
-                                      <includes>
-                                          <include>org.jboss.narayana.jta:*</include>
-                                          <include>org.jboss.narayana.jts:*</include>                                                
-                                      </includes>
-                                  </dependencyManagement>
-                              </import>
-                          </imports>
-                          <overrides>
-                              <override>
-                                  <dependencies>
-                                      <includes>
-                                          <include>org.springframework.cloud:spring-cloud-stream-binder-kafka-test-support</include>
-                                      </includes>
-                                  </dependencies>
-                                  <version>1.1.2</version>
-                              </override>
-                              <override>
-                                  <dependencies>
-                                      <includes>
-                                          <include>org.slf4j:jcl-over-slf4j</include>
-                                      </includes>
-                                  </dependencies>
-                                  <version>${slf4j.version}</version>
-                              </override>
-                              <override>
-                                  <dependencies>
-                                      <includes>
-                                          <include>org.slf4j:log4j-over-slf4j</include>
-                                      </includes>
-                                  </dependencies>
-                                  <version>${slf4j.version}</version>
-                              </override>
-                              <override>
-                                  <dependencies>
-                                      <includes>
-                                          <include>org.apache.activemq:activemq-*</include>
-                                      </includes>
-                                  </dependencies>
-                                  <version>${activemq.version}</version>
-                              </override>
-                              <override>
-                                  <dependencies>
-                                      <includes>
-                                          <include>org.apache.tomcat*:*</include>
-                                      </includes>
-                                  </dependencies>
-                                  <version>${tomcat-embed.version}</version>
-                              </override>
-                              <override>
-                                  <dependencies>
-                                      <includes>
-                                          <include>org.apache.activemq:artemis-*</include>
-                                      </includes>
-                                  </dependencies>
-                                  <version>${artemis.version}</version>
-                              </override>
-                              <override>
-                                  <dependencies>
-                                      <includes>
-                                          <include>org.jboss.narayana.jta:*</include>
-                                          <include>org.jboss.narayana.jts:*</include>
-                                      </includes>
-                                  </dependencies>
-                                  <version>${narayana.version}</version>
-                              </override>
-                              <override>
-                                  <dependencies>
-                                      <includes>
-                                          <include>com.fasterxml.jackson.core:jackson-databind</include>
-                                      </includes>
-                                  </dependencies>
-                                  <version>${jackson2.databind.version}</version>
-                              </override>
-                          </overrides>
-                          <plugins>
-                              <includes>
-                                  <include>io.fabric8:*</include>
-                              </includes>
-                          </plugins>
-                          <properties>
-                              <skipStagingRepositoryClose>true</skipStagingRepositoryClose>
-                          </properties>
-                          <inheritDependencyManagement>true</inheritDependencyManagement>
-                          <inheritPluginManagement>true</inheritPluginManagement>
-                      </bom>
-                  </boms>
-              </configuration>
-              <executions>
-                  <execution>
-                      <goals>
-                          <goal>generate-bom</goal>
-                      </goals>
                   </execution>
               </executions>
           </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,6 @@
         <cxf.plugin.version>3.2.7.fuse-sb2-750015</cxf.plugin.version>
 
         <commons.collections.version>3.2.2.redhat-2</commons.collections.version>
-        <version.fuse-karaf>7.4.0.fuse-740015</version.fuse-karaf>
         <hibernate-validator.version>5.3.5.Final-redhat-2</hibernate-validator.version>
         <hibernate-core.version>5.3.10.Final-redhat-00001</hibernate-core.version>
         <javax.el-api.version>3.0.0</javax.el-api.version>
@@ -144,7 +143,7 @@
         <jetty-plugin.version>9.4.12.v20180830</jetty-plugin.version>
         <jetty.version>9.4.12.v20180830</jetty.version>
 
-	<rhoar.version>2.1.3.Final</rhoar.version>
+	<rhoar.version>2.1.3.Final-redhat-00001</rhoar.version>
         <narayana-spring-boot.version>2.1.1.fuse-sb2-750016</narayana-spring-boot.version>
         <narayana.version>5.9.1.Final-redhat-00001</narayana.version>
 
@@ -172,14 +171,8 @@
         <qpid-proton-j.version>0.31.0.redhat-00001</qpid-proton-j.version>
         <qpid-jms-client.version>0.40.0.redhat-00001</qpid-jms-client.version>
         <reflections.version>0.9.10</reflections.version>
-        <selenium.version>2.53.1</selenium.version>
-        <selenium.firefox.driver.version>2.28.0</selenium.firefox.driver.version>
-        <selenium.htmlunit.driver.version>2.21</selenium.htmlunit.driver.version>
         <shrinkwrap-resolver.version>2.2.2</shrinkwrap-resolver.version>
         <slf4j.version>1.7.22.redhat-2</slf4j.version>
-        <spring.version>4.3.20.RELEASE</spring.version>
-        <spring.boot.version>1.5.17.RELEASE</spring.boot.version>
-        <spring-cloud-kubernetes.version>0.1.6.fuse-740009</spring-cloud-kubernetes.version>
         <tomcat-embed.version>8.0.36.redhat-35</tomcat-embed.version>
         <validation-api.version>1.1.0.Final-redhat-1</validation-api.version>
         <zookeeper.version>3.4.9</zookeeper.version>
@@ -254,11 +247,6 @@
                 <groupId>javax.servlet</groupId>
                 <artifactId>javax.servlet-api</artifactId>
                 <version>${javax.servlet-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>javax.ws.rs</groupId>
-                <artifactId>javax.ws.rs-api</artifactId>
-                <version>${javax.ws.rs-api.version}</version>
             </dependency>
 
             <!-- Eclipse -->
@@ -366,29 +354,9 @@
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>io.fabric8</groupId>
-                <artifactId>fabric8-selenium</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.fabric8</groupId>
-                <artifactId>spring-cloud-kubernetes-bom-with-platform-deps</artifactId>
-                <version>${spring-cloud-kubernetes.version}</version>
-            </dependency>
-            <dependency>
-              <groupId>org.seleniumhq.selenium</groupId>
-              <artifactId>selenium-java</artifactId>
-              <version>${selenium.version}</version>
-            </dependency>
-            <dependency>
               <groupId>com.github.detro</groupId>
               <artifactId>phantomjsdriver</artifactId>
               <version>${phantomjsdriver.version}</version>
-            </dependency>
-            <dependency>
-              <groupId>org.seleniumhq.selenium</groupId>
-              <artifactId>selenium-firefox-driver</artifactId>
-              <version>${selenium.firefox.driver.version}</version>
             </dependency>
 
             <dependency>
@@ -559,44 +527,6 @@
                 <type>xml</type>
                 <classifier>features</classifier>
             </dependency>
-            <dependency>
-                <groupId>org.fusesource</groupId>
-                <artifactId>camel-activemq</artifactId>
-                <version>${version.org.fusesource.camel-sap}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.fusesource</groupId>
-                <artifactId>camel-sap</artifactId>
-                <version>${version.org.fusesource.camel-sap}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.fusesource</groupId>
-                <artifactId>camel-sap-starter</artifactId>
-                <version>${version.org.fusesource.camel-sap}</version>
-            </dependency>
-
-            <!-- Narayana spring-boot -->
-            <dependency>
-                <groupId>me.snowdrop</groupId>
-                <artifactId>narayana-spring-boot-starter</artifactId>
-                <version>${narayana-spring-boot.version}</version>
-            </dependency>
-             <dependency>
-                <groupId>me.snowdrop</groupId>
-                <artifactId>narayana-spring-boot-recovery-controller</artifactId>
-                <version>${narayana-spring-boot.version}</version>
-            </dependency>
-             <dependency>
-                <groupId>me.snowdrop</groupId>
-                <artifactId>narayana-spring-boot-core</artifactId>
-                <version>${narayana-spring-boot.version}</version>
-            </dependency>
-             <dependency>
-                <groupId>me.snowdrop</groupId>
-                <artifactId>narayana-spring-boot-starter-it</artifactId>
-                <version>${narayana-spring-boot.version}</version>
-            </dependency>
-
 
           <!-- Undertow -->
             <dependency>
@@ -614,7 +544,6 @@
                 <artifactId>undertow-websockets-jsr</artifactId>
                 <version>${version.io.undertow}</version>
             </dependency>
-
 
           <!-- Weld -->
             <dependency>
@@ -782,15 +711,6 @@
                 <groupId>org.ops4j.pax.url</groupId>
                 <artifactId>pax-url-aether</artifactId>
                 <version>${pax.url.version}</version>
-            </dependency>
-
-            <!-- Spring -->
-            <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-framework-bom</artifactId>
-                <version>${spring.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
             </dependency>
 
             <!-- EasyMock -->
@@ -965,14 +885,6 @@
                  <type>pom</type>
                  <scope>import</scope>
              </dependency>
-
-            <!-- JBoss Fuse kar 
-            <dependency>
-                <groupId>org.jboss.fuse</groupId>
-                <artifactId>fuse-karaf-framework</artifactId>
-                <type>kar</type>
-                <version>${version.fuse-karaf}</version>
-            </dependency>-->
 
             <dependency>
                  <groupId>io.swagger</groupId>


### PR DESCRIPTION
I've done a number of things here, and we could do more.

Things done : 
- upgrade mockwebserver to fix kubernetes-api tests
- remove fuse-karaf component because we don't need it for sb2
- remove fabric8-spring-boot - do we need that?
- remove fabric8-selenium - do we need that?
- remove selenium and spring-boot dependencies because if we remove fabric8-spring-boot, I don't think we need them

Things we still could do -
- could we remove all of the components after kubernetes-api? (https://github.com/jboss-fuse/fabric8/blob/3.0.11.redhat-7.x/components/pom.xml#L53-L76) 