### PR TITLE
Add fabric8-apt back in

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1030,8 +1030,8 @@
     <modules>
         <module>parent</module>
         <module>components</module>
-<!-- 
         <module>fabric8-apt</module>
+<!--
         <module>hawt-app-maven-plugin</module>
         <module>tooling</module>
 -->


### PR DESCRIPTION
We need to add fabric8-apt back in because it is necessary for the project to build.