### PR TITLE
ENTESB-12031: Missing some starters in Fuse 7.5.0.ER2 SB BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1514,8 +1514,6 @@
                                             <exclude>org.apache.camel:camel-jclouds</exclude>
                                             <exclude>org.apache.camel:camel-jclouds-starter</exclude>
                                             <exclude>org.apache.camel:camel-jetty8</exclude>
-                                            <exclude>org.apache.camel:camel-jira</exclude>
-                                            <exclude>org.apache.camel:camel-jira-starter</exclude>
                                             <exclude>org.apache.camel:camel-jxpath</exclude>
                                             <exclude>org.apache.camel:camel-jxpath-starter</exclude>
                                             <exclude>org.apache.camel:camel-kura</exclude>


### PR DESCRIPTION
re-enabled camel-jira and camel-jirta-starter