### PR TITLE
[ENTESB-12788] Use upstream version of Jasypt 1.9.3 because 1.9.3.red…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -247,9 +247,9 @@
         <snakeyaml-version>1.17</snakeyaml-version>
         <jackson-module-scala-version>2.1.5_3</jackson-module-scala-version>
         <jansi-version>1.11.redhat-1</jansi-version>
-        <jasypt-smx-version>1.9.3.redhat_3</jasypt-smx-version>
-        <jasypt-spring-smx-version>1.9.3.redhat_3</jasypt-spring-smx-version>
-        <jasypt-version>1.9.3.redhat_3</jasypt-version>
+        <jasypt-smx-version>1.9.3_1</jasypt-smx-version>
+        <jasypt-spring-smx-version>1.9.3_1</jasypt-spring-smx-version>
+        <jasypt-version>1.9.3</jasypt-version>
         <javassist-version>3.19.0-GA</javassist-version>
         <javax.inject.bundle.version>1_2</javax.inject.bundle.version>
         <javax.mail.version>1.5.5</javax.mail.version>


### PR DESCRIPTION
…hat_3 had only few changes on top of upstream 1.9.2