### PR TITLE
Upgrade Commons-beanutils to version 1.9.4.redhat-00002

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
         <codehaus-plexus-interpolation-version>1.19</codehaus-plexus-interpolation-version>
         <codehaus-plexus-version>1.5.5</codehaus-plexus-version>
         <codahale-metrics-version>3.0.2</codahale-metrics-version>
-        <commons-beanutils-version>1.9.4.redhat-00001</commons-beanutils-version>
+        <commons-beanutils-version>1.9.4.redhat-00002</commons-beanutils-version>
         <commons-codec-version>1.10.0.redhat-5</commons-codec-version>
         <commons-collections-version>3.2.2.redhat-2</commons-collections-version>
         <commons-compress-version>1.8</commons-compress-version>


### PR DESCRIPTION
Upgrade Commons-beanutils to version 1.9.4.redhat-00002

Cherry-picked from cebe415941f8c4d9a69b7e774ef4397798d98743