### PR TITLE
Changed the maven-notices-plugin to a redhat version

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -37,7 +37,7 @@
         <maven-build-helper-plugin-version>1.8</maven-build-helper-plugin-version>
         <maven-bundle-plugin-version>2.5.3</maven-bundle-plugin-version>
         <maven-javadoc-plugin-version>2.9.1</maven-javadoc-plugin-version>
-        <maven-notices-plugin-version>1.39</maven-notices-plugin-version>
+        <maven-notices-plugin-version>1.39.0.redhat-00001</maven-notices-plugin-version>
         <maven-bundle-summary-plugin-version>1.34</maven-bundle-summary-plugin-version>
         <maven-surefire-plugin-version>2.19.1</maven-surefire-plugin-version>
         <maven-failsafe-plugin-version>2.19.1</maven-failsafe-plugin-version>


### PR DESCRIPTION
The redhat version of the maven-notices-plugin contains a change to allow user properties to be passed through. This is needed so the https.protocols property is propogated so it can access the engineering nexus.